### PR TITLE
CI : Add failure logs for every failed datamodel docker CI job

### DIFF
--- a/.github/workflows/datamodel-test.yml
+++ b/.github/workflows/datamodel-test.yml
@@ -39,6 +39,10 @@ jobs:
       - name: run tests
         run:  docker exec teksi-wastewater pytest
 
+      - name: failure logs
+        if: failure()
+        run: docker logs teksi-wastewater
+
   static-tests:
     name: Run static tests on datamodel
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add failure logs for every failed datamodel docker CI job as proposed by @3nids