### PR TITLE
add test for tww_sys tables

### DIFF
--- a/datamodel/test/test_sys.py
+++ b/datamodel/test/test_sys.py
@@ -39,7 +39,12 @@ class TestSys(unittest.TestCase, DbTestBase):
             if lt not in sys_tables:
                 missing_sys_tables.append(lt)
 
-        extra_sys_tables = []
+        extra_sys_tables = [
+            'network_node',
+            'default_values',
+            'import_manhole_quarantine',
+            'network_segment'
+        ]
         for st in sys_tables:
             if st not in list_tables:
                 extra_sys_tables.append(st)

--- a/datamodel/test/test_sys.py
+++ b/datamodel/test/test_sys.py
@@ -1,0 +1,50 @@
+import os
+import unittest
+
+import psycopg2
+import psycopg2.extras
+
+from .utils import DEFAULT_PG_SERVICE, DbTestBase
+
+
+class TestSys(unittest.TestCase, DbTestBase):
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.rollback()
+
+    @classmethod
+    def setUpClass(cls):
+        pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
+        cls.conn = psycopg2.connect(f"service={pgservice}")
+
+    def test_sys_table(self):
+        list_tables = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'tww_od' AND table_type != 'VIEW'"
+        cur = self.cursor()
+        cur.execute(list_tables)
+        list_tables = []
+        for record in cur.fetchall():
+            list_tables.append(record[0])
+
+        sys_tables = "SELECT tablename FROM tww_sys.dictionary_od_table"
+        cur = self.cursor()
+        cur.execute(sys_tables)
+        sys_tables = []
+        for record in cur.fetchall():
+            sys_tables.append(record[0])
+
+        missing_sys_tables = []
+        for lt in list_tables:
+            if lt not in sys_tables:
+                missing_sys_tables.append(lt)
+
+        extra_sys_tables = []
+        for st in sys_tables:
+            if st not in list_tables:
+                extra_sys_tables.append(st)
+
+        self.assertEqual(missing_sys_tables, [])
+        self.assertEqual(extra_sys_tables, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/datamodel/test/test_sys.py
+++ b/datamodel/test/test_sys.py
@@ -40,10 +40,10 @@ class TestSys(unittest.TestCase, DbTestBase):
                 missing_sys_tables.append(lt)
 
         extra_sys_tables = [
-            'network_node',
-            'default_values',
-            'import_manhole_quarantine',
-            'network_segment'
+            "network_node",
+            "default_values",
+            "import_manhole_quarantine",
+            "network_segment",
         ]
         for st in sys_tables:
             if st not in list_tables:

--- a/datamodel/test/test_sys.py
+++ b/datamodel/test/test_sys.py
@@ -5,7 +5,6 @@ try:
     import psycopg
 except ImportError:
     import psycopg2 as psycopg
-    import psycopg2.extras as psycopg_extras
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 

--- a/datamodel/test/test_sys.py
+++ b/datamodel/test/test_sys.py
@@ -1,8 +1,11 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+try:
+    import psycopg
+except ImportError:
+    import psycopg2 as psycopg
+    import psycopg2.extras as psycopg_extras
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -15,7 +18,7 @@ class TestSys(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_sys_table(self):
         list_tables = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'tww_od' AND table_type != 'VIEW'"


### PR DESCRIPTION
we have tables in the od schema which are not listed in tww_sys.dictionnary_od_table:

reach_text => ?
wastewater_structure_text => ?
catchment_area_text => ?
reach_progression_alternative => ?
_planning_zone => ?
_aquifier => ?
wastewater_structure_symbol => ?

import_manhole_quarantine => should be skipped
network_node => should be skipped
network_segment => should be skipped

@sjib can you add the missing tables or explain what to do?