### PR TITLE
upgrade to psycopg3

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qgis_version: [3.28-jammy, latest]
+        qgis_version: [3.34-jammy, latest]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
       COMPOSE_PROFILES: qgis
@@ -40,6 +40,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup env
+        run: cp .env.example .env
+
       - name: Package PyPI Packages
         run: sudo ./plugin/scripts/package-pip-packages.sh
 
@@ -47,7 +50,7 @@ jobs:
         run: sudo ./plugin/scripts/download-interlis-libs.sh
 
       - name: Docker build
-        run: docker compose up -d --build
+        run: docker compose --profile qgis up -d --build
 
       - name: Test on QGIS
         run: docker-compose run qgis /usr/src/plugin/.docker/run-docker-tests.sh

--- a/datamodel/.docker/Dockerfile
+++ b/datamodel/.docker/Dockerfile
@@ -27,7 +27,6 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install -r datamodel/requirements.txt
 RUN if [ "${RUN_TEST}" = "True" ]; then pip install -r datamodel/requirements-test.txt; fi
 
-
 # Configure the postgres connections
 RUN printf '[postgres]\ndbname=postgres\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 RUN printf '[pg_tww]\ndbname=tww\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
@@ -41,7 +40,7 @@ RUN if [ "${AUTO_INIT}" = "True" ]; then ln -s /src/datamodel/.docker/init_db.sh
 
 # Some defaults
 ENV POSTGRES_PASSWORD=postgres
-# otherwise psycopg2 cannot connect
+# otherwise psycopg cannot connect
 ENV PGSERVICEFILE=/etc/postgresql-common/pg_service.conf
 
 ENV PGSERVICE=pg_tww

--- a/datamodel/app/swmm_views/04_vw_swmm_conduits.sql
+++ b/datamodel/app/swmm_views/04_vw_swmm_conduits.sql
@@ -113,7 +113,7 @@ SELECT
 	END
 	) as description,
 	cfhy.value_en as tag,
-	ST_CurveToLine(st_force3d(progression3d_geometry))::geometry(LineStringZ, %(SRID)s) as geom,
+	ST_CurveToLine(st_force3d(progression3d_geometry))::geometry(LineStringZ, {SRID}) as geom,
 	CASE
 		WHEN status IN (7959, 6529, 6526) THEN 'planned'
 		ELSE 'current'

--- a/datamodel/app/swmm_views/09_vw_swmm_subcatchments.sql
+++ b/datamodel/app/swmm_views/09_vw_swmm_subcatchments.sql
@@ -69,7 +69,7 @@ SELECT
 		THEN NULL
 	END as description,
   ca.obj_id as tag,
-  ST_CurveToLine(perimeter_geometry)::geometry(Polygon, %(SRID)s) as geom,
+  ST_CurveToLine(perimeter_geometry)::geometry(Polygon, {SRID}) as geom,
   CASE
     WHEN state = 'rw_current' OR state = 'ww_current' THEN 'current'
     WHEN state = 'rw_planned' OR state = 'ww_planned' THEN 'planned'

--- a/datamodel/app/swmm_views/12_vw_swmm_raingages.sql
+++ b/datamodel/app/swmm_views/12_vw_swmm_raingages.sql
@@ -6,7 +6,7 @@ SELECT
   '0:15'::varchar as Interval,
   '1.0'::varchar as SCF,
   'TIMESERIES default_tww_raingage_timeserie'::varchar as Source,
-  st_centroid(perimeter_geometry)::geometry(Point, %(SRID)s) as geom,
+  st_centroid(perimeter_geometry)::geometry(Point, {SRID}) as geom,
   state,
   CASE
 		WHEN _function_hierarchic in (5062, 5064, 5066, 5068, 5069, 5070, 5071, 5072, 5074) THEN 'primary'

--- a/datamodel/app/view/catchment_area/vw_catchment_area_connections.sql
+++ b/datamodel/app/view/catchment_area/vw_catchment_area_connections.sql
@@ -5,9 +5,9 @@ SELECT
 
 ca.obj_id,
 ST_Force2D(ST_MakeLine(ST_Centroid(ST_CurveToLine(perimeter_geometry)),
-wn_rw_current.situation3d_geometry))::geometry( LineString, %(SRID)s ) AS connection_rw_current_geometry,
+wn_rw_current.situation3d_geometry))::geometry( LineString, {SRID} ) AS connection_rw_current_geometry,
 ST_Force2D(ST_MakeLine(ST_Centroid(ST_CurveToLine(perimeter_geometry)),
-wn_ww_current.situation3d_geometry))::geometry( LineString, %(SRID)s ) AS connection_ww_current_geometry
+wn_ww_current.situation3d_geometry))::geometry( LineString, {SRID} ) AS connection_ww_current_geometry
 
 FROM tww_od.catchment_area ca
 LEFT JOIN tww_od.wastewater_node wn_rw_current

--- a/datamodel/app/view/create_views.py
+++ b/datamodel/app/view/create_views.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-import psycopg2
+import psycopg
 from pirogue import MultipleInheritance, SimpleJoins, SingleInheritance
 from vw_tww_reach import vw_tww_reach
 from vw_tww_wastewater_structure import vw_tww_wastewater_structure
@@ -13,9 +13,9 @@ from yaml import safe_load
 
 def run_sql(file_path: str, pg_service: str, variables: dict = {}):
     sql = open(file_path).read()
-    conn = psycopg2.connect(f"service={pg_service}")
+    conn = psycopg.connect(f"service={pg_service}")
     cursor = conn.cursor()
-    cursor.execute(sql, variables)
+    cursor.execute(psycopg.sql.SQL(sql).format(**variables))
     conn.commit()
     conn.close()
 

--- a/datamodel/app/view/vw_change_points.sql
+++ b/datamodel/app/view/vw_change_points.sql
@@ -1,7 +1,7 @@
 CREATE VIEW tww_app.vw_change_points AS
 SELECT
   rp_to.obj_id,
-  rp_to.situation3d_geometry::geometry(POINTZ, %(SRID)s) AS geom,
+  rp_to.situation3d_geometry::geometry(POINTZ, {SRID}) AS geom,
   re.material <> re_next.material AS change_in_material,
   re.clear_height <> re_next.clear_height AS change_in_clear_height,
   (rp_from.level - rp_to.level) / re.length_effective - (rp_next_from.level - rp_next_to.level) / re_next.length_effective AS change_in_slope

--- a/datamodel/app/view/vw_oo_overflow.yaml
+++ b/datamodel/app/view/vw_oo_overflow.yaml
@@ -4,7 +4,7 @@ view_name: vw_tww_overflow
 view_schema: tww_app
 
 additional_columns:
-  geometry: n1.situation3d_geometry::geometry('PointZ',%(SRID)s)
+  geometry: n1.situation3d_geometry::geometry('PointZ',{SRID})
 additional_joins: >
   LEFT JOIN tww_od.wastewater_node n1 ON overflow.fk_wastewater_node::text = n1.obj_id::text
 

--- a/datamodel/app/view/vw_tww_reach.py
+++ b/datamodel/app/view/vw_tww_reach.py
@@ -5,7 +5,7 @@
 import argparse
 import os
 
-import psycopg2
+import psycopg
 from pirogue.utils import insert_command, select_columns, table_parts, update_command
 from yaml import safe_load
 
@@ -21,7 +21,7 @@ def vw_tww_reach(pg_service: str = None, extra_definition: dict = None):
     assert pg_service
     extra_definition = extra_definition or {}
 
-    conn = psycopg2.connect(f"service={pg_service}")
+    conn = psycopg.connect(f"service={pg_service}")
     cursor = conn.cursor()
 
     view_sql = """

--- a/datamodel/app/view/vw_tww_wastewater_structure.py
+++ b/datamodel/app/view/vw_tww_wastewater_structure.py
@@ -5,7 +5,7 @@
 import argparse
 import os
 
-import psycopg2
+import psycopg
 from pirogue.utils import insert_command, select_columns, table_parts, update_command
 from yaml import safe_load
 
@@ -22,9 +22,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
     assert pg_service
     extra_definition = extra_definition or {}
 
-    variables = {"SRID": int(srid)}
-
-    conn = psycopg2.connect(f"service={pg_service}")
+    conn = psycopg.connect(f"service={pg_service}")
     cursor = conn.cursor()
 
     view_sql = """
@@ -56,7 +54,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
         , main_co_sp.renovation_demand AS co_renovation_demand
 
         , {main_co_cols}
-        , ST_Force2D(COALESCE(wn.situation3d_geometry, main_co.situation3d_geometry))::geometry(Point, %(SRID)s) AS situation3d_geometry
+        , ST_Force2D(COALESCE(wn.situation3d_geometry, main_co.situation3d_geometry))::geometry(Point, {srid}) AS situation3d_geometry
 
         , {ma_columns}
 
@@ -94,6 +92,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
         ALTER VIEW tww_app.vw_tww_wastewater_structure ALTER co_obj_id SET DEFAULT tww_sys.generate_oid('tww_od','cover');
         ALTER VIEW tww_app.vw_tww_wastewater_structure ALTER wn_obj_id SET DEFAULT tww_sys.generate_oid('tww_od','wastewater_node');
     """.format(
+        srid=srid,
         extra_cols="\n    ".join(
             [
                 select_columns(
@@ -221,7 +220,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
         ),
     )
 
-    cursor.execute(view_sql, variables)
+    cursor.execute(view_sql)
 
     trigger_insert_sql = """
     CREATE OR REPLACE FUNCTION tww_app.ft_vw_tww_wastewater_structure_INSERT()
@@ -438,7 +437,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
         SET situation3d_geometry = ST_SetSRID( ST_MakePoint(
         ST_X(ST_TRANSLATE(ST_MakePoint(ST_X(WN.situation3d_geometry), ST_Y(WN.situation3d_geometry)), dx, dy )),
         ST_Y(ST_TRANSLATE(ST_MakePoint(ST_X(WN.situation3d_geometry), ST_Y(WN.situation3d_geometry)), dx, dy )),
-        ST_Z(WN.situation3d_geometry)), %(SRID)s )
+        ST_Z(WN.situation3d_geometry)), {srid} )
         WHERE obj_id IN
         (
           SELECT obj_id FROM tww_od.wastewater_networkelement
@@ -450,7 +449,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
         SET situation3d_geometry = ST_SetSRID( ST_MakePoint(
         ST_X(ST_TRANSLATE(ST_MakePoint(ST_X(CO.situation3d_geometry), ST_Y(CO.situation3d_geometry)), dx, dy )),
         ST_Y(ST_TRANSLATE(ST_MakePoint(ST_X(CO.situation3d_geometry), ST_Y(CO.situation3d_geometry)), dx, dy )),
-        ST_Z(CO.situation3d_geometry)), %(SRID)s )
+        ST_Z(CO.situation3d_geometry)), {srid} )
         WHERE obj_id IN
         (
           SELECT obj_id FROM tww_od.structure_part
@@ -466,7 +465,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
             ST_SetSRID( ST_MakePoint(
                 ST_X(ST_TRANSLATE(ST_MakePoint(ST_X(ST_PointN(RE.progression3d_geometry, 1)), ST_Y(ST_PointN(RE.progression3d_geometry, 1))), dx, dy )),
                 ST_Y(ST_TRANSLATE(ST_MakePoint(ST_X(ST_PointN(RE.progression3d_geometry, 1)), ST_Y(ST_PointN(RE.progression3d_geometry, 1))), dx, dy )),
-                ST_Z(ST_PointN(RE.progression3d_geometry, 1))), %(SRID)s )
+                ST_Z(ST_PointN(RE.progression3d_geometry, 1))), {srid} )
           ) )
         WHERE fk_reach_point_from IN
         (
@@ -483,7 +482,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
             ST_SetSRID( ST_MakePoint(
                 ST_X(ST_TRANSLATE(ST_MakePoint(ST_X(ST_EndPoint(RE.progression3d_geometry)), ST_Y(ST_EndPoint(RE.progression3d_geometry))), dx, dy )),
                 ST_Y(ST_TRANSLATE(ST_MakePoint(ST_X(ST_EndPoint(RE.progression3d_geometry)), ST_Y(ST_EndPoint(RE.progression3d_geometry))), dx, dy )),
-                ST_Z(ST_PointN(RE.progression3d_geometry, 1))), %(SRID)s )
+                ST_Z(ST_PointN(RE.progression3d_geometry, 1))), {srid} )
           ) )
         WHERE fk_reach_point_to IN
         (
@@ -505,6 +504,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
     CREATE TRIGGER vw_tww_wastewater_structure_UPDATE INSTEAD OF UPDATE ON tww_app.vw_tww_wastewater_structure
       FOR EACH ROW EXECUTE PROCEDURE tww_app.ft_vw_tww_wastewater_structure_UPDATE();
     """.format(
+        srid=srid,
         update_co=update_command(
             pg_cur=cursor,
             table_schema="tww_od",
@@ -605,7 +605,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
         ),
     )
 
-    cursor.execute(update_trigger_sql, variables)
+    cursor.execute(update_trigger_sql)
 
     trigger_delete_sql = """
     CREATE OR REPLACE FUNCTION tww_app.ft_vw_tww_wastewater_structure_DELETE()
@@ -622,7 +622,8 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
     CREATE TRIGGER vw_tww_wastewater_structure_DELETE INSTEAD OF DELETE ON tww_app.vw_tww_wastewater_structure
       FOR EACH ROW EXECUTE PROCEDURE tww_app.ft_vw_tww_wastewater_structure_DELETE();
     """
-    cursor.execute(trigger_delete_sql, variables)
+
+    cursor.execute(trigger_delete_sql)
 
     extras = """
     ALTER VIEW tww_app.vw_tww_wastewater_structure ALTER obj_id SET DEFAULT tww_sys.generate_oid('tww_od','wastewater_structure');

--- a/datamodel/requirements.txt
+++ b/datamodel/requirements.txt
@@ -1,3 +1,3 @@
-pirogue>=1.4.2
-psycopg2
+pirogue>=2.0.1
+psycopg>=3.1.18
 pyyaml

--- a/datamodel/test/test_geometry.py
+++ b/datamodel/test/test_geometry.py
@@ -2,8 +2,7 @@ import copy
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -19,7 +18,7 @@ class TestGeometry(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_vw_tww_reach_geometry_insert(self):
         # 1. insert geometry with Z and no rp_from_level and no rp_to_level

--- a/datamodel/test/test_import.py
+++ b/datamodel/test/test_import.py
@@ -2,9 +2,7 @@ import decimal
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
-import psycopg2.sql
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -17,7 +15,7 @@ class TestImport(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     # - level calculation failing because only no reference level
     #   -> not updated structure with calculated values
@@ -207,14 +205,14 @@ class TestImport(unittest.TestCase, DbTestBase):
         # it should be in the live table tww_od.reach and tww_od.reach_point
         cur = self.cursor()
         cur.execute(
-            psycopg2.sql.SQL(
+            psycopg.sql.SQL(
                 "SELECT re.material, re.clear_height, rp.level, ws.co_level\
             FROM {schema}.reach re\
             LEFT JOIN {schema}.reach_point rp ON rp.obj_id = re.fk_reach_point_from\
             LEFT JOIN {schema}.wastewater_networkelement wn ON wn.obj_id = rp.fk_wastewater_networkelement\
             LEFT JOIN {schema}.vw_tww_wastewater_structure ws ON ws.obj_id = wn.fk_wastewater_structure\
             WHERE ws.obj_id = %(obj_id)s"
-            ).format(schema=psycopg2.sql.Identifier("tww_od")),
+            ).format(schema=psycopg.sql.Identifier("tww_od")),
             {"obj_id": obj_id},
         )
         row = cur.fetchone()
@@ -227,11 +225,11 @@ class TestImport(unittest.TestCase, DbTestBase):
         row = self.select("file", obj_id, "tww_od")
         cur = self.cursor()
         cur.execute(
-            psycopg2.sql.SQL(
+            psycopg.sql.SQL(
                 "SELECT *\
             FROM {schema}.file\
             WHERE object = %(obj_id)s"
-            ).format(schema=psycopg2.sql.Identifier("tww_od")),
+            ).format(schema=psycopg.sql.Identifier("tww_od")),
             {"obj_id": obj_id},
         )
         row = cur.fetchone()
@@ -262,7 +260,7 @@ class TestImport(unittest.TestCase, DbTestBase):
         # it should be in the live table tww_od.reach and tww_od.reach_point
         cur = self.cursor()
         cur.execute(
-            psycopg2.sql.SQL(
+            psycopg.sql.SQL(
                 "SELECT re.material, re.clear_height, rp.level, ws.co_level\
             FROM tww_od.reach re\
             LEFT JOIN tww_od.reach_point rp ON rp.obj_id = re.fk_reach_point_from\
@@ -339,14 +337,14 @@ class TestImport(unittest.TestCase, DbTestBase):
         # it should be in the live table tww_od.reach and tww_od.reach_point
         cur = self.cursor()
         cur.execute(
-            psycopg2.sql.SQL(
+            psycopg.sql.SQL(
                 "SELECT re.material, re.clear_height, rp.level, ws.co_level\
             FROM {schema}.reach re\
             LEFT JOIN {schema}.reach_point rp ON rp.obj_id = re.fk_reach_point_from\
             LEFT JOIN {schema}.wastewater_networkelement wn ON wn.obj_id = rp.fk_wastewater_networkelement\
             LEFT JOIN {schema}.vw_tww_wastewater_structure ws ON ws.obj_id = wn.fk_wastewater_structure\
             WHERE ws.obj_id = %(obj_id)s"
-            ).format(schema=psycopg2.sql.Identifier("tww_od")),
+            ).format(schema=psycopg.sql.Identifier("tww_od")),
             {"obj_id": obj_id},
         )
         row = cur.fetchone()
@@ -442,14 +440,14 @@ class TestImport(unittest.TestCase, DbTestBase):
         # it should be in the live table tww_od.reach and tww_od.reach_point
         cur = self.cursor()
         cur.execute(
-            psycopg2.sql.SQL(
+            psycopg.sql.SQL(
                 "SELECT re.material, re.clear_height, rp.level, ws.co_level\
             FROM {schema}.reach re\
             LEFT JOIN {schema}.reach_point rp ON rp.obj_id = re.fk_reach_point_from\
             LEFT JOIN {schema}.wastewater_networkelement wn ON wn.obj_id = rp.fk_wastewater_networkelement\
             LEFT JOIN {schema}.vw_tww_wastewater_structure ws ON ws.obj_id = wn.fk_wastewater_structure\
             WHERE ws.obj_id = %(obj_id)s"
-            ).format(schema=psycopg2.sql.Identifier("tww_od")),
+            ).format(schema=psycopg.sql.Identifier("tww_od")),
             {"obj_id": obj_id},
         )
         row = cur.fetchone()
@@ -477,8 +475,8 @@ class TestImport(unittest.TestCase, DbTestBase):
         # it should be in the live table tww_od.reach and tww_od.reach_point
         cur = self.cursor()
         cur.execute(
-            psycopg2.sql.SQL("SELECT * FROM {schema}.wastewater_structure LIMIT 1").format(
-                schema=psycopg2.sql.Identifier("tww_od")
+            psycopg.sql.SQL("SELECT * FROM {schema}.wastewater_structure LIMIT 1").format(
+                schema=psycopg.sql.Identifier("tww_od")
             )
         )
         row = cur.fetchone()

--- a/datamodel/test/test_label.py
+++ b/datamodel/test/test_label.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -15,7 +14,7 @@ class TestViews(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def insert_manholes(self, manholes):
         for manhole in manholes:

--- a/datamodel/test/test_network.py
+++ b/datamodel/test/test_network.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -28,7 +27,7 @@ class TestNetwork(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def make_reach(self, identifier, x1, y1, x2, y2):
         """
@@ -89,7 +88,7 @@ class TestNetwork(unittest.TestCase, DbTestBase):
         SELECT obj_id, depth
         FROM downstream;
         """
-        cur = self.cursor()
+        cur = self.cursor(row_factory=psycopg.rows.dict_row)
         cur.execute(query, (node_id,))
         return {row["obj_id"]: row["depth"] for row in cur.fetchall()}
 
@@ -116,7 +115,7 @@ class TestNetwork(unittest.TestCase, DbTestBase):
         SELECT obj_id, depth
         FROM upstream
         """
-        cur = self.cursor()
+        cur = self.cursor(row_factory=psycopg.rows.dict_row)
         cur.execute(query, (node_id,))
         return {row["obj_id"]: row["depth"] for row in cur.fetchall()}
 

--- a/datamodel/test/test_on_delete.py
+++ b/datamodel/test/test_on_delete.py
@@ -2,8 +2,7 @@ import decimal
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -16,7 +15,7 @@ class TestOnDelete(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_delete_wastewater_structure(self):
         # Create a new cover(structure part) with manhole(wastewater structure)

--- a/datamodel/test/test_removed_fields.py
+++ b/datamodel/test/test_removed_fields.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -15,10 +14,10 @@ class TestRemovedFields(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_dataowner(self):
-        cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur = self.conn.cursor(row_factory=psycopg.rows.dict_row)
 
         cur.execute("SELECT * FROM tww_od.wastewater_structure LIMIT 1")
         colnames = [desc[0] for desc in cur.description]

--- a/datamodel/test/test_schemas.py
+++ b/datamodel/test/test_schemas.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -18,7 +17,7 @@ class TestSchemas(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_list_schemas(self):
         schemas = ", ".join([f"'{schema}'" for schema in TWW_SCHEMAS + PG_SCHEMAS])

--- a/datamodel/test/test_swmm.py
+++ b/datamodel/test/test_swmm.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -19,7 +18,7 @@ class TestSwmm(unittest.TestCase, DbTestBase):
     @classmethod
     def setUp(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_count_vw_aquifers(self):
         self.assert_count("swmm_vw_aquifers", "tww_app", 0)

--- a/datamodel/test/test_symbology.py
+++ b/datamodel/test/test_symbology.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -15,7 +14,7 @@ class TestViews(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_create_drop_triggers(self):
         self.execute("tww_sys.disable_symbology_triggers()")

--- a/datamodel/test/test_triggers.py
+++ b/datamodel/test/test_triggers.py
@@ -2,8 +2,7 @@ import decimal
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -16,7 +15,7 @@ class TestTriggers(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_last_modified(self):
         row = {

--- a/datamodel/test/test_views.py
+++ b/datamodel/test/test_views.py
@@ -3,8 +3,7 @@ import decimal
 import os
 import unittest
 
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 from .utils import DEFAULT_PG_SERVICE, DbTestBase
 
@@ -17,7 +16,7 @@ class TestViews(unittest.TestCase, DbTestBase):
     @classmethod
     def setUpClass(cls):
         pgservice = os.environ.get("PGSERVICE") or DEFAULT_PG_SERVICE
-        cls.conn = psycopg2.connect(f"service={pgservice}")
+        cls.conn = psycopg.connect(f"service={pgservice}")
 
     def test_vw_reach(self):
         row = {
@@ -93,7 +92,7 @@ class TestViews(unittest.TestCase, DbTestBase):
 
         self.update_check("vw_tww_wastewater_structure", row, obj_id)
 
-        cur = self.cursor()
+        cur = self.cursor(row_factory=psycopg.rows.dict_row)
 
         cur.execute(
             "SELECT * FROM tww_od.wastewater_networkelement NE LEFT JOIN tww_od.wastewater_node NO ON NO.obj_id = NE.obj_id WHERE fk_wastewater_structure='{obj_id}' ".format(

--- a/datamodel/test/utils.py
+++ b/datamodel/test/utils.py
@@ -1,5 +1,4 @@
-import psycopg2
-import psycopg2.extras
+import psycopg
 
 DEFAULT_PG_SERVICE = "pg_tww"
 
@@ -7,7 +6,7 @@ DEFAULT_PG_SERVICE = "pg_tww"
 class DbTestBase:
     @classmethod
     def assert_count(cls, table, schema, expected):
-        cur = cls.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur = cls.conn.cursor()
         cur.execute(f"SELECT COUNT(*) FROM {schema}.{table}")
         count = cur.fetchone()[0]
         assert (
@@ -24,26 +23,26 @@ class DbTestBase:
 
     @classmethod
     def select(cls, table, obj_id, schema="tww_app"):
-        cur = cls.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur = cls.conn.cursor(row_factory=psycopg.rows.dict_row)
         cur.execute(f"SELECT * FROM {schema}.{table} WHERE obj_id=%(obj_id)s", {"obj_id": obj_id})
         return cur.fetchone()
 
     @classmethod
     def execute(cls, sql: str, params=[]):
-        cur = cls.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur = cls.conn.cursor()
         if not sql.startswith("SELECT"):
             sql = f"SELECT {sql}"
         cur.execute(sql, params)
         return cur.fetchone()[0]
 
     def check_empty(self, sql: str):
-        cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur = self.conn.cursor()
         cur.execute(sql)
         self.assertIsNone(cur.fetchone())
 
     @classmethod
-    def cursor(cls):
-        return cls.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    def cursor(cls, **kwargs):
+        return cls.conn.cursor(**kwargs)
 
     @classmethod
     def insert(cls, table, row, schema="tww_app"):

--- a/datamodel/update/post-all.py
+++ b/datamodel/update/post-all.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-import psycopg2
+import psycopg
 from pum.core.deltapy import DeltaPy
 from view.create_views import create_views
 
@@ -25,7 +25,7 @@ class CreateViews(DeltaPy):
         )
 
         # refresh network views
-        conn = psycopg2.connect(f"service={self.pg_service}")
+        conn = psycopg.connect(f"service={self.pg_service}")
         cursor = conn.cursor()
         cursor.execute("SELECT tww_app.network_refresh_network_simple();")
         conn.commit()

--- a/docs/en/installation-guide/requirements.rst
+++ b/docs/en/installation-guide/requirements.rst
@@ -5,6 +5,6 @@ Requirements
 
 The following Python packages (installed using `pip <https://pypi.org/project/pip/>`_) are required:
 
-* `Psycopg2 <https://www.psycopg.org/>`_ as database adapter
+* `Psycopg <https://www.psycopg.org/>`_ as database adapter
 * `Pirogue <https://github.com/opengisch/pirogue>`_ for model generation and upgrades
 * `PUM <https://github.com/opengisch/pum>`_ for model upgrades

--- a/plugin/.docker/Dockerfile
+++ b/plugin/.docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG QGIS_TEST_VERSION=latest
-FROM  opengisch/qgis:${QGIS_TEST_VERSION}
+FROM  qgis/qgis:${QGIS_TEST_VERSION}
 
 # remove QGIS apt repo to avoid signing key issues
 RUN add-apt-repository -r  https://qgis.org/ubuntu && \
@@ -9,6 +9,9 @@ RUN apt-get update && \
     apt-get -y install openjdk-8-jre curl locales postgresql-client python3-geoalchemy2 \
     && rm -rf /var/lib/apt/lists/*
 
+# remove when https://github.com/qgis/qgis-docker/pull/95 is merged
+RUN pip install psycopg
+
 RUN printf '[postgres]\ndbname=postgres\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 RUN printf '[pg_tww]\ndbname=tww\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 
@@ -16,10 +19,7 @@ RUN printf '[pg_tww]\ndbname=tww\nuser=postgres\n' >> /etc/postgresql-common/pg_
 ENV POSTGRES_PASSWORD=postgres
 # otherwise psycopg2 cannot connect
 ENV PGSERVICEFILE=/etc/postgresql-common/pg_service.conf
-
 ENV PGSERVICE=pg_tww
-
-
 ENV LANG=C.UTF-8
 
 WORKDIR /

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -2,7 +2,7 @@ import logging
 import os
 import tempfile
 
-import psycopg2
+import psycopg
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication
 
@@ -26,7 +26,7 @@ from .utils.ili2db import InterlisTools
 from .utils.various import (
     CmdException,
     LoggingHandlerContext,
-    get_pgconf_as_psycopg2_dsn,
+    get_pgconf_as_psycopg_dsn,
     logger,
     make_log_path,
 )
@@ -233,8 +233,7 @@ class InterlisImporterExporter:
         return interlisImporterToIntermediateSchema.session_tww
 
     def _import_update_main_cover_and_refresh_mat_views(self):
-        connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
-        connection.set_session(autocommit=True)
+        connection = psycopg.connect(get_pgconf_as_psycopg_dsn(), autocommit=True)
         cursor = connection.cursor()
 
         logger.info("Update wastewater structure fk_main_cover")
@@ -386,8 +385,7 @@ class InterlisImporterExporter:
     def _clear_ili_schema(self, recreate_schema=False):
         logger.info("CONNECTING TO DATABASE...")
 
-        connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
-        connection.set_session(autocommit=True)
+        connection = psycopg.connect(get_pgconf_as_psycopg_dsn(), autocommit=True)
         cursor = connection.cursor()
 
         if not recreate_schema:

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -236,8 +236,8 @@ def get_pgconf():
     return collections.defaultdict(str, pgconf)
 
 
-def get_pgconf_as_psycopg2_dsn() -> List[str]:
-    """Returns the pgconf as a psycopg2 connection string"""
+def get_pgconf_as_psycopg_dsn() -> List[str]:
+    """Returns the pgconf as a psycopg connection string"""
 
     pgconf = get_pgconf()
     parts = []

--- a/plugin/teksi_wastewater/processing_provider/TwwSwmm.py
+++ b/plugin/teksi_wastewater/processing_provider/TwwSwmm.py
@@ -21,7 +21,7 @@ import codecs
 import subprocess
 from datetime import datetime, timedelta
 
-import psycopg2
+import psycopg
 
 MEASURING_POINT_KIND = "Diverse kind of SWMM simulation parameters"
 MEASURING_DEVICE_REMARK = "SWMM Simulation"
@@ -134,7 +134,7 @@ class TwwSwmm:
 
     def __enter__(self):
         if self.service is not None:
-            self.con = psycopg2.connect(service=self.service)
+            self.con = psycopg.connect(service=self.service)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -207,7 +207,7 @@ class TwwSwmm:
             )
         try:
             cur.execute(sql)
-        except psycopg2.ProgrammingError:
+        except psycopg.ProgrammingError:
             self.feedback_push("error", f"Error while executing: {sql}")
             return None, None
         self.feedback_push("info", f"Process vw_{table_name}")
@@ -872,9 +872,9 @@ class TwwSwmm:
             )
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", str(psycopg2.ProgrammingError))
+                self.feedback_push("error", str(psycopg.ProgrammingError))
                 return None, None
             res = cur.fetchone()
             if res is None:
@@ -937,9 +937,9 @@ class TwwSwmm:
             )
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", str(psycopg2.ProgrammingError))
+                self.feedback_push("error", str(psycopg.ProgrammingError))
                 return None, None
             res = cur.fetchone()
             if res is None:
@@ -1001,9 +1001,9 @@ class TwwSwmm:
             )
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", str(psycopg2.ProgrammingError))
+                self.feedback_push("error", str(psycopg.ProgrammingError))
                 return None
             res = cur.fetchone()
             mp_obj_id = res[0]
@@ -1052,9 +1052,9 @@ class TwwSwmm:
             )
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", str(psycopg2.ProgrammingError))
+                self.feedback_push("error", str(psycopg.ProgrammingError))
                 return None, None
             res = cur.fetchone()
             if res is None:
@@ -1115,9 +1115,9 @@ class TwwSwmm:
 
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", str(psycopg2.ProgrammingError))
+                self.feedback_push("error", str(psycopg.ProgrammingError))
                 return None
             ms_obj_id = cur.fetchone()[0]
             self.con.commit()
@@ -1158,9 +1158,9 @@ class TwwSwmm:
         )
         try:
             cur.execute(sql)
-        except psycopg2.ProgrammingError:
+        except psycopg.ProgrammingError:
             self.feedback_push("error", f"Error while excecuting: {sql}")
-            self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+            self.feedback_push("error", (str(psycopg.ProgrammingError)))
             return None
         res = cur.fetchone()
 
@@ -1184,9 +1184,9 @@ class TwwSwmm:
 
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+                self.feedback_push("error", (str(psycopg.ProgrammingError)))
                 return None
             mr_obj_id = cur.fetchone()[0]
             self.con.commit()
@@ -1203,9 +1203,9 @@ class TwwSwmm:
             )
             try:
                 cur.execute(sql)
-            except psycopg2.ProgrammingError:
+            except psycopg.ProgrammingError:
                 self.feedback_push("error", f"Error while excecuting: {sql}")
-                self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+                self.feedback_push("error", (str(psycopg.ProgrammingError)))
                 return None
             mr_obj_id = cur.fetchone()[0]
             self.con.commit()
@@ -1225,9 +1225,9 @@ class TwwSwmm:
         """
         try:
             cur.execute(sql)
-        except psycopg2.ProgrammingError:
+        except psycopg.ProgrammingError:
             self.feedback_push("error", f"Error while excecuting: {sql}")
-            self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+            self.feedback_push("error", (str(psycopg.ProgrammingError)))
             return None
         self.con.commit()
         del cur
@@ -1246,9 +1246,9 @@ class TwwSwmm:
         """
         try:
             cur.execute(sql)
-        except psycopg2.ProgrammingError:
+        except psycopg.ProgrammingError:
             self.feedback_push("error", f"Error while excecuting: {sql}")
-            self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+            self.feedback_push("error", (str(psycopg.ProgrammingError)))
             return None
         self.con.commit()
         del cur
@@ -1270,9 +1270,9 @@ class TwwSwmm:
         """
         try:
             cur.execute(sql)
-        except psycopg2.ProgrammingError:
+        except psycopg.ProgrammingError:
             self.feedback_push("error", f"Error while excecuting: {sql}")
-            self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+            self.feedback_push("error", (str(psycopg.ProgrammingError)))
             return None
         self.con.commit()
         del cur
@@ -1294,9 +1294,9 @@ class TwwSwmm:
         """
         try:
             cur.execute(sql)
-        except psycopg2.ProgrammingError:
+        except psycopg.ProgrammingError:
             self.feedback_push("error", f"Error while excecuting: {sql}")
-            self.feedback_push("error", (str(psycopg2.ProgrammingError)))
+            self.feedback_push("error", (str(psycopg.ProgrammingError)))
             return None
         self.con.commit()
         del cur


### PR DESCRIPTION
* pirogue has been moved to psycopg3 and now accepts parameters given in curly braces (see https://github.com/opengisch/pirogue/releases/tag/2.0.1)
* code has been updated accordingly
* qgis Docker image for plugin test has been moved from opengis to upstream QGIS repo and upgraded to QGIS 3.34 from now on, since 3.28 is not available (this has no implication on TWW QGIS project)
