### PR TITLE
add psycopg2 support

### DIFF
--- a/plugin/.docker/Dockerfile
+++ b/plugin/.docker/Dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
     apt-get -y install openjdk-8-jre curl locales postgresql-client python3-geoalchemy2 \
     && rm -rf /var/lib/apt/lists/*
 
-# remove when https://github.com/qgis/qgis-docker/pull/95 is merged
-RUN pip install psycopg
-
 RUN printf '[postgres]\ndbname=postgres\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 RUN printf '[pg_tww]\ndbname=tww\nuser=postgres\n' >> /etc/postgresql-common/pg_service.conf
 

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -2,7 +2,17 @@ import logging
 import os
 import tempfile
 
-import psycopg
+try:
+    import psycopg
+
+    PSYCOPG_VERSION = 3
+    DEFAULTS_CONN_ARG = {"autocommit": True}
+except ImportError:
+    import psycopg2 as psycopg
+
+    PSYCOPG_VERSION = 2
+    DEFAULTS_CONN_ARG = {}
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication
 
@@ -233,7 +243,9 @@ class InterlisImporterExporter:
         return interlisImporterToIntermediateSchema.session_tww
 
     def _import_update_main_cover_and_refresh_mat_views(self):
-        connection = psycopg.connect(get_pgconf_as_psycopg_dsn(), autocommit=True)
+        connection = psycopg.connect(get_pgconf_as_psycopg_dsn(), **DEFAULTS_CONN_ARG)
+        if PSYCOPG_VERSION == 2:
+            connection.set_session(autocommit=True)
         cursor = connection.cursor()
 
         logger.info("Update wastewater structure fk_main_cover")
@@ -385,7 +397,9 @@ class InterlisImporterExporter:
     def _clear_ili_schema(self, recreate_schema=False):
         logger.info("CONNECTING TO DATABASE...")
 
-        connection = psycopg.connect(get_pgconf_as_psycopg_dsn(), autocommit=True)
+        connection = psycopg.connect(get_pgconf_as_psycopg_dsn(), **DEFAULTS_CONN_ARG)
+        if PSYCOPG_VERSION == 2:
+            connection.set_session(autocommit=True)
         cursor = connection.cursor()
 
         if not recreate_schema:

--- a/plugin/teksi_wastewater/processing_provider/TwwSwmm.py
+++ b/plugin/teksi_wastewater/processing_provider/TwwSwmm.py
@@ -21,7 +21,10 @@ import codecs
 import subprocess
 from datetime import datetime, timedelta
 
-import psycopg
+try:
+    import psycopg
+except ImportError:
+    import psycopg2 as psycopg
 
 MEASURING_POINT_KIND = "Diverse kind of SWMM simulation parameters"
 MEASURING_DEVICE_REMARK = "SWMM Simulation"


### PR DESCRIPTION
I just realized that we probably don't have support for psycopg3 under certain environment for now (OSGeo4W at least).

So, we have to make the plugin compatible with psycopg2 at least.
We will leave the test to work on psycopg2 as it's the most critical environment.