### PR TITLE
include oid_prefix in interlis text class export

### DIFF
--- a/plugin/teksi_wastewater/interlis/config.py
+++ b/plugin/teksi_wastewater/interlis/config.py
@@ -14,6 +14,7 @@ ILIVALIDATOR = os.path.join(BASE, "bin", "ilivalidator-1.11.9", "ilivalidator-1.
 TWW_DEFAULT_PGSERVICE = "pg_tww"
 TWW_OD_SCHEMA = "tww_od"
 TWW_VL_SCHEMA = "tww_vl"
+TWW_SYS_SCHEMA = "tww_sys"
 ABWASSER_SCHEMA = "pg2ili_abwasser"
 MODEL_NAME_VSA_KEK = "VSA_KEK_2020_1_LV95"
 MODEL_NAME_SIA405_ABWASSER = "SIA405_ABWASSER_2020_1_LV95"

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -64,7 +64,6 @@ class InterlisImporterExporter:
         self.model_classes_tww_vl = None
         self.model_classes_tww_sys = None
 
-
         self.current_progress = 0
 
     def interlis_import(self, xtf_file_input, show_selection_dialog=False, logs_next_to_file=True):

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -62,6 +62,8 @@ class InterlisImporterExporter:
         self.model_classes_interlis = None
         self.model_classes_tww_od = None
         self.model_classes_tww_vl = None
+        self.model_classes_tww_sys = None
+
 
         self.current_progress = 0
 

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -30,8 +30,8 @@ from .interlis_model_mapping.model_interlis_sia405_abwasser import (
     ModelInterlisSia405Abwasser,
 )
 from .interlis_model_mapping.model_interlis_vsa_kek import ModelInterlisVsaKek
+from .interlis_model_mapping.model_tww import ModelTwwSys, ModelTwwVl
 from .interlis_model_mapping.model_tww_od import ModelTwwOd
-from .interlis_model_mapping.model_tww import ModelTwwVl,ModelTwwSys
 from .utils.ili2db import InterlisTools
 from .utils.various import (
     CmdException,
@@ -459,7 +459,7 @@ class InterlisImporterExporter:
         if self.model_classes_tww_vl is None:
             self.model_classes_tww_vl = ModelTwwVl().classes()
             self._progress_done(self.current_progress + 1)
-        
+
         if self.model_classes_tww_sys is None:
             self.model_classes_tww_sys = ModelTwwSys().classes()
             self._progress_done(self.current_progress + 1)

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -31,7 +31,7 @@ from .interlis_model_mapping.model_interlis_sia405_abwasser import (
 )
 from .interlis_model_mapping.model_interlis_vsa_kek import ModelInterlisVsaKek
 from .interlis_model_mapping.model_tww_od import ModelTwwOd
-from .interlis_model_mapping.model_tww_vl import ModelTwwVl
+from .interlis_model_mapping.model_tww import ModelTwwVl,ModelTwwSys
 from .utils.ili2db import InterlisTools
 from .utils.various import (
     CmdException,
@@ -321,6 +321,7 @@ class InterlisImporterExporter:
             model_classes_interlis=self.model_classes_interlis,
             model_classes_tww_od=self.model_classes_tww_od,
             model_classes_tww_vl=self.model_classes_tww_vl,
+            model_classes_tww_sys=self.model_classes_tww_sys,
             selection=selected_ids,
             labels_file=labels_file_path,
             basket_enabled=basket_enabled,
@@ -457,6 +458,10 @@ class InterlisImporterExporter:
 
         if self.model_classes_tww_vl is None:
             self.model_classes_tww_vl = ModelTwwVl().classes()
+            self._progress_done(self.current_progress + 1)
+        
+        if self.model_classes_tww_sys is None:
+            self.model_classes_tww_sys = ModelTwwSys().classes()
             self._progress_done(self.current_progress + 1)
 
     def _progress_done_intermediate_schema(self):

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2402,7 +2402,7 @@ class InterlisExporterToIntermediateSchema:
         return val
 
     def get_oid_prefix(self, oid_table):
-        instance = self.tww_session.query(oid_table).filter(oid_table.active == True).first()
+        instance = self.tww_session.query(oid_table).filter(oid_table.active is True).first()
         if instance is None:
             logger.warning(
                 f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". Setting to default instead.'

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2405,10 +2405,10 @@ class InterlisExporterToIntermediateSchema:
         instance = self.tww_session.query(oid_table).filter(oid_table.active is True).first()
         if instance is None:
             logger.warning(
-                f"Could not find an active entry in table\"{oid_table.__table__.schema}.{oid_table.__name__}\". \
+                f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". \
                 Returning an empty string, which will lead to Interlis Errors. \
-                Set the value that you want to use as prefix to 'active' in table\"{oid_table.__table__.schema}.{oid_table.__name__}\" \
-                to avoid this issue."
+                Set the value that you want to use as prefix to \'active\' in table"{oid_table.__table__.schema}.{oid_table.__name__}" \
+                to avoid this issue.'
             )
             return ""
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2405,9 +2405,12 @@ class InterlisExporterToIntermediateSchema:
         instance = self.tww_session.query(oid_table).filter(oid_table.active is True).first()
         if instance is None:
             logger.warning(
-                f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". Setting to default instead.'
+                f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". \
+                Returning an empty string, which will lead to Interlis Errors. \
+                Set the value \'active\' in table"{oid_table.__table__.schema}.{oid_table.__name__}" to \
+                \'True\' to avoid this issue.'
             )
-            return "ch080txt"  # TODO: is this prefix owned by TEKSI?
+            return "" 
 
         return instance.prefix
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2407,7 +2407,7 @@ class InterlisExporterToIntermediateSchema:
             logger.warning(
                 f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". Setting to default instead.'
             )
-            return 'ch080txt' #TODO: is this prefix owned by TEKSI?
+            return "ch080txt"  # TODO: is this prefix owned by TEKSI?
 
         return instance.prefix
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2405,12 +2405,12 @@ class InterlisExporterToIntermediateSchema:
         instance = self.tww_session.query(oid_table).filter(oid_table.active is True).first()
         if instance is None:
             logger.warning(
-                f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". \
+                f"Could not find an active entry in table\"{oid_table.__table__.schema}.{oid_table.__name__}\". \
                 Returning an empty string, which will lead to Interlis Errors. \
-                Set the value \'active\' in table"{oid_table.__table__.schema}.{oid_table.__name__}" to \
-                \'True\' to avoid this issue.'
+                Set the value 'active' in table\"{oid_table.__table__.schema}.{oid_table.__name__}\" to \
+                'True' to avoid this issue."
             )
-            return "" 
+            return ""
 
         return instance.prefix
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -20,6 +20,7 @@ class InterlisExporterToIntermediateSchema:
         model_classes_interlis,
         model_classes_tww_od,
         model_classes_tww_vl,
+        model_classes_tww_sys,
         selection=None,
         labels_file=None,
         basket_enabled=False,
@@ -47,6 +48,7 @@ class InterlisExporterToIntermediateSchema:
         self.model_classes_interlis = model_classes_interlis
         self.model_classes_tww_od = model_classes_tww_od
         self.model_classes_tww_vl = model_classes_tww_vl
+        self.model_classes_tww_sys = model_classes_tww_sys
 
         self.tww_session = None
         self.abwasser_session = None
@@ -2399,6 +2401,16 @@ class InterlisExporterToIntermediateSchema:
             val = 0
         return val
 
+    def get_oid_prefix(self, oid_table):
+        instance = self.tww_session.query(oid_table).filter(oid_table.active == True).first()
+        if instance is None:
+            logger.warning(
+                f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". Setting to default instead.'
+            )
+            return 'ch080txt' #TODO: is this prefix owned by TEKSI?
+
+        return instance.prefix
+
     def base_common(self, row, type_name):
         """
         Returns common attributes for base
@@ -2589,7 +2601,7 @@ class InterlisExporterToIntermediateSchema:
         Returns common attributes for textpos
         """
         t_id = self.tid_maker.next_tid()
-
+        oid_prefix = self.get_oid_prefix(self.model_classes_tww_sys.oid_prefixes)
         if t_id > 999999:
             logger.warning(
                 f"Exporting more than 999999 labels will generate invalid OIDs. Currently exporting {t_id} label of type '{t_type}'."
@@ -2598,7 +2610,7 @@ class InterlisExporterToIntermediateSchema:
         return {
             "t_id": t_id,
             "t_type": t_type,
-            "t_ili_tid": f"ch080txt{shortcut_en}{t_id:06d}",
+            "t_ili_tid": f"{oid_prefix}{shortcut_en}{t_id:06d}",
             # --- TextPos ---
             "textpos": ST_GeomFromGeoJSON(
                 json.dumps(

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2407,8 +2407,8 @@ class InterlisExporterToIntermediateSchema:
             logger.warning(
                 f"Could not find an active entry in table\"{oid_table.__table__.schema}.{oid_table.__name__}\". \
                 Returning an empty string, which will lead to Interlis Errors. \
-                Set the value 'active' in table\"{oid_table.__table__.schema}.{oid_table.__name__}\" to \
-                'True' to avoid this issue."
+                Set the value that you want to use as prefix to 'active' in table\"{oid_table.__table__.schema}.{oid_table.__name__}\" \
+                to avoid this issue."
             )
             return ""
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/model_tww.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/model_tww.py
@@ -5,3 +5,8 @@ from .model_base import ModelBase
 class ModelTwwVl(ModelBase):
     def __init__(self):
         super().__init__(config.TWW_VL_SCHEMA)
+
+
+class ModelTwwSys(ModelBase):
+    def __init__(self):
+        super().__init__(config.TWW_SYS_SCHEMA)


### PR DESCRIPTION
This PR 

- renames model_tww_vl to model_tww in the model mapping 
- adds a class for tww_sys in model_tww
- includes a query to tww_sys in the interlis export of labels