### PR TITLE
alter filtering type for oid prefix selection

### DIFF
--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -42,7 +42,8 @@ class InterlisExporterToIntermediateSchema:
 
         self.labels_file = labels_file
         self.use_vsacode = use_vsacode
-
+        self.oid_prefix=None
+        
         self.basket_enabled = basket_enabled
 
         self.model_classes_interlis = model_classes_interlis
@@ -59,6 +60,7 @@ class InterlisExporterToIntermediateSchema:
         self.basket_topic_sia405_abwasser = None
         self.basket_topic_dss = None
         self.basket_topic_kek = None
+        
 
     def tww_export(self):
         # Logging disabled (very slow)
@@ -2599,12 +2601,11 @@ class InterlisExporterToIntermediateSchema:
             "steuerungszentraleref": self.get_tid(row.fk_control_center__REL),
         }
 
-    def _textpos_common(self, row, t_type, geojson_crs_def, shortcut_en):
+    def _textpos_common(self, row, t_type, geojson_crs_def, shortcut_en, oid_prefix):
         """
         Returns common attributes for textpos
         """
         t_id = self.tid_maker.next_tid()
-        oid_prefix = self.get_oid_prefix(self.model_classes_tww_sys.oid_prefixes)
         if t_id > 999999:
             logger.warning(
                 f"Exporting more than 999999 labels will generate invalid OIDs. Currently exporting {t_id} label of type '{t_type}'."
@@ -2635,7 +2636,9 @@ class InterlisExporterToIntermediateSchema:
 
     def _export_label_positions(self):
         logger.info(f"Exporting label positions from {self.labels_file}")
-
+        
+        # get oid prefix
+        self.oid_prefix = self.get_oid_prefix(self.model_classes_tww_sys.oid_prefixes)
         # Get t_id by obj_name to create the reference on the labels below
         tid_for_obj_id = {
             "vw_tww_reach": {},
@@ -2681,19 +2684,19 @@ class InterlisExporterToIntermediateSchema:
 
             if layer_name == "vw_tww_reach":
                 ili_label = self.model_classes_interlis.haltung_text(
-                    **self._textpos_common(label, "haltung_text", geojson_crs_def, "RX"),
+                    **self._textpos_common(label, "haltung_text", geojson_crs_def, "RX", self.oid_prefix),
                     haltungref=t_id,
                 )
 
             elif layer_name == "vw_tww_wastewater_structure":
                 ili_label = self.model_classes_interlis.abwasserbauwerk_text(
-                    **self._textpos_common(label, "abwasserbauwerk_text", geojson_crs_def, "WX"),
+                    **self._textpos_common(label, "abwasserbauwerk_text", geojson_crs_def, "WX",self.oid_prefix),
                     abwasserbauwerkref=t_id,
                 )
 
             elif layer_name == "catchment_area":
                 ili_label = self.model_classes_interlis.einzugsgebiet_text(
-                    **self._textpos_common(label, "einzugsgebiet_text", geojson_crs_def, "CX"),
+                    **self._textpos_common(label, "einzugsgebiet_text", geojson_crs_def, "CX",self.oid_prefix),
                     einzugsgebietref=t_id,
                 )
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -2402,7 +2402,7 @@ class InterlisExporterToIntermediateSchema:
         return val
 
     def get_oid_prefix(self, oid_table):
-        instance = self.tww_session.query(oid_table).filter(oid_table.active is True).first()
+        instance = self.tww_session.query(oid_table).filter(oid_table.active.is_(True)).first()
         if instance is None:
             logger.warning(
                 f'Could not find an active entry in table"{oid_table.__table__.schema}.{oid_table.__name__}". \

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -42,8 +42,8 @@ class InterlisExporterToIntermediateSchema:
 
         self.labels_file = labels_file
         self.use_vsacode = use_vsacode
-        self.oid_prefix=None
-        
+        self.oid_prefix = None
+
         self.basket_enabled = basket_enabled
 
         self.model_classes_interlis = model_classes_interlis
@@ -60,7 +60,6 @@ class InterlisExporterToIntermediateSchema:
         self.basket_topic_sia405_abwasser = None
         self.basket_topic_dss = None
         self.basket_topic_kek = None
-        
 
     def tww_export(self):
         # Logging disabled (very slow)
@@ -2636,7 +2635,7 @@ class InterlisExporterToIntermediateSchema:
 
     def _export_label_positions(self):
         logger.info(f"Exporting label positions from {self.labels_file}")
-        
+
         # get oid prefix
         self.oid_prefix = self.get_oid_prefix(self.model_classes_tww_sys.oid_prefixes)
         # Get t_id by obj_name to create the reference on the labels below
@@ -2684,19 +2683,25 @@ class InterlisExporterToIntermediateSchema:
 
             if layer_name == "vw_tww_reach":
                 ili_label = self.model_classes_interlis.haltung_text(
-                    **self._textpos_common(label, "haltung_text", geojson_crs_def, "RX", self.oid_prefix),
+                    **self._textpos_common(
+                        label, "haltung_text", geojson_crs_def, "RX", self.oid_prefix
+                    ),
                     haltungref=t_id,
                 )
 
             elif layer_name == "vw_tww_wastewater_structure":
                 ili_label = self.model_classes_interlis.abwasserbauwerk_text(
-                    **self._textpos_common(label, "abwasserbauwerk_text", geojson_crs_def, "WX",self.oid_prefix),
+                    **self._textpos_common(
+                        label, "abwasserbauwerk_text", geojson_crs_def, "WX", self.oid_prefix
+                    ),
                     abwasserbauwerkref=t_id,
                 )
 
             elif layer_name == "catchment_area":
                 ili_label = self.model_classes_interlis.einzugsgebiet_text(
-                    **self._textpos_common(label, "einzugsgebiet_text", geojson_crs_def, "CX",self.oid_prefix),
+                    **self._textpos_common(
+                        label, "einzugsgebiet_text", geojson_crs_def, "CX", self.oid_prefix
+                    ),
                     einzugsgebietref=t_id,
                 )
 


### PR DESCRIPTION
This PR fixes the selection of the oid prefix. `active == false` worked but didn't pass flake. is True always return 0 for some reason. Now using builtin function is_. 

Additionally, The oid_prefix is no longer re-evaluated on every textpos but once per export