### PR TITLE
use 2d length for length_effective if rp_level is zero

### DIFF
--- a/datamodel/app/symbology_functions.sql
+++ b/datamodel/app/symbology_functions.sql
@@ -733,9 +733,12 @@ BEGIN
   SELECT rp_to.level INTO _rp_to_level
   FROM tww_od.reach_point rp_to
   WHERE NEW.fk_reach_point_to = rp_to.obj_id;
-
-  NEW.length_effective = COALESCE(sqrt((_rp_from_level - _rp_to_level)^2 + ST_Length(NEW.progression3d_geometry)^2), ST_Length(NEW.progression3d_geometry) );
-
+  
+  IF _rp_from_level=0 OR _rp_to_level=0 THEN
+    NEW.length_effective = ST_Length(NEW.progression3d_geometry);
+  ELSE
+    NEW.length_effective = COALESCE(sqrt((_rp_from_level - _rp_to_level)^2 + ST_Length(NEW.progression3d_geometry)^2), ST_Length(NEW.progression3d_geometry) );
+  END IF
   RETURN NEW;
 
 END;

--- a/datamodel/app/symbology_functions.sql
+++ b/datamodel/app/symbology_functions.sql
@@ -738,7 +738,7 @@ BEGIN
     NEW.length_effective = ST_Length(NEW.progression3d_geometry);
   ELSE
     NEW.length_effective = COALESCE(sqrt((_rp_from_level - _rp_to_level)^2 + ST_Length(NEW.progression3d_geometry)^2), ST_Length(NEW.progression3d_geometry) );
-  END IF:
+  END IF;
   RETURN NEW;
 
 END;

--- a/datamodel/app/symbology_functions.sql
+++ b/datamodel/app/symbology_functions.sql
@@ -738,7 +738,7 @@ BEGIN
     NEW.length_effective = ST_Length(NEW.progression3d_geometry);
   ELSE
     NEW.length_effective = COALESCE(sqrt((_rp_from_level - _rp_to_level)^2 + ST_Length(NEW.progression3d_geometry)^2), ST_Length(NEW.progression3d_geometry) );
-  END IF
+  END IF:
   RETURN NEW;
 
 END;


### PR DESCRIPTION
When importing data that has zero values for rp_level, the reach.length_effective should not be calculated in 3D.