### PR TITLE
fix label export orientation

### DIFF
--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -183,8 +183,6 @@ class InterlisImporterExporter:
             labels_file_path = os.path.join(tempdir.name, "labels.geojson")
             self._export_labels_file(
                 limit_to_selection=limit_to_selection,
-                # neu export orientation
-                export_orientation=export_orientation,
                 selected_labels_scales_indices=selected_labels_scales_indices,
                 labels_file_path=labels_file_path,
             )
@@ -312,7 +310,6 @@ class InterlisImporterExporter:
     def _export_labels_file(
         self,
         limit_to_selection,
-        export_orientation,
         selected_labels_scales_indices,
         labels_file_path,
     ):
@@ -345,7 +342,6 @@ class InterlisImporterExporter:
             {
                 "OUTPUT": labels_file_path,
                 "RESTRICT_TO_SELECTION": limit_to_selection,
-                "EXPORT_ORIENTATION": export_orientation,
                 "STRUCTURE_VIEW_LAYER": structures_lyr,
                 "REACH_VIEW_LAYER": reaches_lyr,
                 "SCALES": selected_labels_scales_indices,
@@ -375,6 +371,7 @@ class InterlisImporterExporter:
             model_classes_tww_od=self.model_classes_tww_od,
             model_classes_tww_vl=self.model_classes_tww_vl,
             model_classes_tww_sys=self.model_classes_tww_sys,
+            labels_orientation_offset=export_orientation,
             selection=selected_ids,
             labels_file=labels_file_path,
             basket_enabled=basket_enabled,

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -21,7 +21,7 @@ class InterlisExporterToIntermediateSchema:
         model_classes_tww_od,
         model_classes_tww_vl,
         model_classes_tww_sys,
-        labels_orientation_offset,
+        labels_orientation_offset=90,
         selection=None,
         labels_file=None,
         basket_enabled=False,

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -51,7 +51,7 @@ class InterlisExporterToIntermediateSchema:
         self.model_classes_tww_od = model_classes_tww_od
         self.model_classes_tww_vl = model_classes_tww_vl
         self.model_classes_tww_sys = model_classes_tww_sys
-        self.labels_orientation_offset=labels_orientation_offset
+        self.labels_orientation_offset = labels_orientation_offset
 
         self.tww_session = None
         self.abwasser_session = None
@@ -2399,7 +2399,7 @@ class InterlisExporterToIntermediateSchema:
         """
         if val is None:
             return None
-        
+
         # add labels_orientation_offset
         val = val + self.labels_orientation_offset
 

--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -21,6 +21,7 @@ class InterlisExporterToIntermediateSchema:
         model_classes_tww_od,
         model_classes_tww_vl,
         model_classes_tww_sys,
+        labels_orientation_offset,
         selection=None,
         labels_file=None,
         basket_enabled=False,
@@ -50,6 +51,7 @@ class InterlisExporterToIntermediateSchema:
         self.model_classes_tww_od = model_classes_tww_od
         self.model_classes_tww_vl = model_classes_tww_vl
         self.model_classes_tww_sys = model_classes_tww_sys
+        self.labels_orientation_offset=labels_orientation_offset
 
         self.tww_session = None
         self.abwasser_session = None
@@ -2391,15 +2393,15 @@ class InterlisExporterToIntermediateSchema:
             logger.warning(f"Value '{val}' exceeds expected length ({max_length})", stacklevel=2)
         return val[0:max_length]
 
-    def _modulo_angle(self, val, labels_orientation_offset):
+    def _modulo_angle(self, val):
         """
         Returns an angle between 0 and 359.9 (for Orientierung in Base_d-20181005.ili)
         """
         if val is None:
             return None
-
+        
         # add labels_orientation_offset
-        val = val + labels_orientation_offset
+        val = val + self.labels_orientation_offset
 
         val = val % 360.0
         if val > 359.9:


### PR DESCRIPTION
Up to now, the labels_orientation_offset is not passed to the function _modulo_angle in the intermediate schema.

This PR takes the changes from #217 and applies the following fixes:

- tww:extractlabels_interlis has no Parameter "EXPORT_ORIENTATION". Parameter is dropped on export of labels. file.
- On Export, the orientation offset is passed to the intermediate schema
- Without this PR, the export of labels will not work