### PR TITLE
[WIP] Add listener to DatabaseUtils

### DIFF
--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -155,7 +155,7 @@ class TeksiWastewaterPlugin:
             self.iface.mainWindow(), ["vw_wastewater_node", "vw_tww_reach"]
         )
         self.wastewater_structure_layer_notifier = TwwLayerNotifier(
-            self.iface.mainWindow(), ["vw_wastewater_structure"]
+            self.iface.mainWindow(), ["vw_tww_wastewater_structure"]
         )
 
         self.toolbarButtons = []

--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -157,7 +157,7 @@ class TeksiWastewaterPlugin:
         self.wastewater_structure_layer_notifier = TwwLayerNotifier(
             self.iface.mainWindow(), ["vw_wastewater_structure"]
         )
-        
+
         self.toolbarButtons = []
 
         # Create toolbar button
@@ -338,7 +338,7 @@ class TeksiWastewaterPlugin:
         self.wastewater_networkelement_layer_notifier.layersAvailableChanged.connect(
             self._wastewater_networkelement_layer_available_changed
         )
-        
+
         self.wastewater_structure_layer_notifier.layersAvailableChanged.connect(
             self._wastewater_structure_layer_available_changed
         )
@@ -657,26 +657,26 @@ class TeksiWastewaterPlugin:
             self._configure_database_connection_config_from_tww_layer()
 
             self.tww_validity_check_startup()
-            no_cover_payload = DatabaseUtils.dblisten('vw_tww_ws_no_cover')
+            no_cover_payload = DatabaseUtils.dblisten("vw_tww_ws_no_cover")
             for payload in no_cover_payload:
                 self.iface.messageBar().pushMessage(
-                            "Warning",
-                            payload,
-                            level=Qgis.Warning,
-                        )
-                        
+                    "Warning",
+                    payload,
+                    level=Qgis.Warning,
+                )
+
     def _wastewater_structure_layer_available_changed(self, available):
 
         if available:
             self._configure_database_connection_config_from_tww_layer()
 
-            no_cover_payload = DatabaseUtils.dblisten('vw_tww_ws_no_cover')
+            no_cover_payload = DatabaseUtils.dblisten("vw_tww_ws_no_cover")
             for payload in no_cover_payload:
                 self.iface.messageBar().pushMessage(
-                            "Warning",
-                            payload,
-                            level=Qgis.Warning,
-                        )
+                    "Warning",
+                    payload,
+                    level=Qgis.Warning,
+                )
 
     def update_admin_mode(self):
 

--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -657,13 +657,6 @@ class TeksiWastewaterPlugin:
             self._configure_database_connection_config_from_tww_layer()
 
             self.tww_validity_check_startup()
-            no_cover_payload = DatabaseUtils.dblisten("vw_tww_ws_no_cover")
-            for payload in no_cover_payload:
-                self.iface.messageBar().pushMessage(
-                    "Warning",
-                    payload,
-                    level=Qgis.Warning,
-                )
 
     def _wastewater_structure_layer_available_changed(self, available):
 

--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -154,6 +154,10 @@ class TeksiWastewaterPlugin:
         self.wastewater_networkelement_layer_notifier = TwwLayerNotifier(
             self.iface.mainWindow(), ["vw_wastewater_node", "vw_tww_reach"]
         )
+        self.wastewater_structure_layer_notifier = TwwLayerNotifier(
+            self.iface.mainWindow(), ["vw_wastewater_structure"]
+        )
+        
         self.toolbarButtons = []
 
         # Create toolbar button
@@ -333,6 +337,10 @@ class TeksiWastewaterPlugin:
 
         self.wastewater_networkelement_layer_notifier.layersAvailableChanged.connect(
             self._wastewater_networkelement_layer_available_changed
+        )
+        
+        self.wastewater_structure_layer_notifier.layersAvailableChanged.connect(
+            self._wastewater_structure_layer_available_changed
         )
 
         self.processing_provider = TwwProcessingProvider()
@@ -649,6 +657,26 @@ class TeksiWastewaterPlugin:
             self._configure_database_connection_config_from_tww_layer()
 
             self.tww_validity_check_startup()
+            no_cover_payload = DatabaseUtils.dblisten('vw_tww_ws_no_cover')
+            for payload in no_cover_payload:
+                self.iface.messageBar().pushMessage(
+                            "Warning",
+                            payload,
+                            level=Qgis.Warning,
+                        )
+                        
+    def _wastewater_structure_layer_available_changed(self, available):
+
+        if available:
+            self._configure_database_connection_config_from_tww_layer()
+
+            no_cover_payload = DatabaseUtils.dblisten('vw_tww_ws_no_cover')
+            for payload in no_cover_payload:
+                self.iface.messageBar().pushMessage(
+                            "Warning",
+                            payload,
+                            level=Qgis.Warning,
+                        )
 
     def update_admin_mode(self):
 

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -223,7 +223,7 @@ class DatabaseUtils:
         return messages
 
     @staticmethod
-    def dblisten(channel str,timeout int = 5):
+    def dblisten(channel str,timeout: float = 5.0):
         with DatabaseUtils.PsycopgConnection() as connection:
             cursor = connection.cursor()
             cursor.execute(f"LISTEN {channel}")

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -223,7 +223,7 @@ class DatabaseUtils:
         return messages
 
     @staticmethod
-    def dblisten(channel str,timeout int = 5) ->str:
+    def dblisten(channel str,timeout int = 5):
         with DatabaseUtils.PsycopgConnection() as connection:
             cursor = connection.cursor()
             cursor.execute(f"LISTEN {channel}")

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -223,20 +223,21 @@ class DatabaseUtils:
         return messages
 
     @staticmethod
-    def dblisten(channel str,timeout: float = 5.0):
-        with DatabaseUtils.PsycopgConnection() as connection:
-            cursor = connection.cursor()
-            cursor.execute(f"LISTEN {channel}")
-            try:
-                while True:
-                    if select.select([connection], [], [], timeout) == ([], [], []):
-                        print (f'Timeout on Channel {channel}')
-                    else:
-                        connection.poll()
-                        events = []
-                        while connection.notifies:
-                            notify = connection.notifies.pop()
-                            yield notify.payload
-            finally:
-                cursor.execute(f'UNLISTEN {channel}')
-                cursor.close()
+    def dblisten(channel: str = None, timeout: float = 5.0):
+        if channel:
+            with DatabaseUtils.PsycopgConnection() as connection:
+                cursor = connection.cursor()
+                cursor.execute(f"LISTEN {channel}")
+                try:
+                    while True:
+                        if select.select([connection], [], [], timeout) == ([], [], []):
+                            print (f'Timeout on Channel {channel}')
+                        else:
+                            connection.poll()
+                            events = []
+                            while connection.notifies:
+                                notify = connection.notifies.pop()
+                                yield notify.payload
+                finally:
+                    cursor.execute(f'UNLISTEN {channel}')
+                    cursor.close()

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -1,8 +1,8 @@
 import collections
 import configparser
 import os
-from typing import List
 import select
+from typing import List
 
 from .plugin_utils import logger
 
@@ -230,7 +230,7 @@ class DatabaseUtils:
             try:
                 while True:
                     if select.select([connection], [], [], timeout) == ([], [], []):
-                        print (f'Timeout on Channel {channel}') 
+                        print (f'Timeout on Channel {channel}')
                     else:
                         connection.poll()
                         events = []

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -231,13 +231,12 @@ class DatabaseUtils:
                 try:
                     while True:
                         if select.select([connection], [], [], timeout) == ([], [], []):
-                            print (f'Timeout on Channel {channel}')
+                            print(f"Timeout on Channel {channel}")
                         else:
                             connection.poll()
-                            events = []
                             while connection.notifies:
                                 notify = connection.notifies.pop()
                                 yield notify.payload
                 finally:
-                    cursor.execute(f'UNLISTEN {channel}')
+                    cursor.execute(f"UNLISTEN {channel}")
                     cursor.close()


### PR DESCRIPTION
In order to push warnings etc. from the db to QGIS iface (as needed i.e. in #36), we need to have a plugin side option to listen to pg_notify events. I try to get there via this draft PR, yet it needs technical validation (to make sure we properly close the connections every time).

### planned usage

add pg_notify in a trigger function on the database side, i.e. the on insert of wastewater structure

https://github.com/teksi/wastewater/blob/a7dc88240bbfd8e45b68b5b305c1f7633a2bf90e/datamodel/app/view/vw_tww_wastewater_structure.py#L276-L284

On the plugin side, we connect the Channel 'vw_tww_ws_no_cover' using

```
no_cover_payload = DatabaseUtils.dblisten('vw_tww_ws_no_cover')
for payload in no_cover_payload:
    self.iface.messageBar().pushMessage(
                "Warning",
                payload,
                level=Qgis.Warning,
            )
```