### PR TITLE
Create baskets to manage multiple datasets in one database

### DIFF
--- a/datamodel/changelogs/0001/oid_generation.sql
+++ b/datamodel/changelogs/0001/oid_generation.sql
@@ -69,14 +69,14 @@ DECLARE
   myrec_seq record;
   basket int;
 BEGIN
-  
+
   SELECT t_basket INTO basket FROM tww_od.oid_manager WHERE usr_name=current_user;
-  IF NOT FOUND THEN 
+  IF NOT FOUND THEN
 	SELECT id INTO STRICT basket FROM tww_sys.oid_prefixes WHERE active;
 
 	INSERT INTO tww_od.oid_manager(usr_name,t_basket) VALUES (current_user,basket)
   END IF;
-  
+
   -- first get the OID prefix
   BEGIN
       SELECT prefix::text INTO myrec_prefix FROM tww_sys.oid_prefixes WHERE id = basket;

--- a/datamodel/changelogs/0001/oid_generation.sql
+++ b/datamodel/changelogs/0001/oid_generation.sql
@@ -44,13 +44,13 @@ CREATE TABLE tww_od.oid_manager
 (
   id serial NOT NULL,
   usr_name text NOT NULL,
-  t_basket int NOT NULL
+  t_basket int NOT NULL,
   CONSTRAINT pkey_tww_od_oid_manager_id PRIMARY KEY (id),
   CONSTRAINT uniq_tww_od_oid_manager_usr_name UNIQUE (usr_name),
   CONSTRAINT fkey_od_oid_manager_t_basket FOREIGN KEY (t_basket)
         REFERENCES tww_sys.oid_prefixes (id) MATCH SIMPLE
         ON UPDATE CASCADE
-        ON DELETE SET NULL;
+        ON DELETE SET NULL
 );
 COMMENT ON TABLE tww_sys.oid_prefixes
   IS 'This table contains OID prefixes for different communities or organizations.';

--- a/datamodel/changelogs/0001/oid_generation.sql
+++ b/datamodel/changelogs/0001/oid_generation.sql
@@ -73,8 +73,7 @@ BEGIN
   SELECT t_basket INTO basket FROM tww_od.oid_manager WHERE usr_name=current_user;
   IF NOT FOUND THEN
 	SELECT id INTO STRICT basket FROM tww_sys.oid_prefixes WHERE active;
-
-	INSERT INTO tww_od.oid_manager(usr_name,t_basket) VALUES (current_user,basket)
+	INSERT INTO tww_od.oid_manager(usr_name,t_basket) VALUES (current_user,basket);
   END IF;
 
   -- first get the OID prefix

--- a/datamodel/changelogs/0001/oid_generation.sql
+++ b/datamodel/changelogs/0001/oid_generation.sql
@@ -124,17 +124,17 @@ DECLARE
     intval bigint  := abs(base10);
     char0z char[]  := regexp_split_to_array('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ', '');
 BEGIN
-    IF base10 = 0 
-	THEN 
-		base36 := '0'; 
+    IF base10 = 0
+	THEN
+		base36 := '0';
 	ELSE
 		WHILE intval != 0 LOOP
 			base36 := char0z[(intval % 36)+1] || base36;
 			intval := intval / 36;
 		END LOOP;
 	END IF;
-	IF min_width > 0 AND char_length(base36) < min_width THEN 
-			base36 := lpad(base36, min_width, '0'); 
+	IF min_width > 0 AND char_length(base36) < min_width THEN
+			base36 := lpad(base36, min_width, '0');
 		END IF;
     RETURN base36;
 END;

--- a/datamodel/create_baskets.py
+++ b/datamodel/create_baskets.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+
+try:
+    import psycopg
+except ImportError:
+    import psycopg2 as psycopg
+
+    
+def create_od_baskets(pg_service: str):
+    conn = psycopg.connect(f"service={pg_service}")
+    cursor = conn.cursor()
+    cursor.execute("""
+        SELECT table_name
+        FROM information_schema.columns 
+        WHERE table_schema = 'tww_od'
+        GROUP BY table_name
+        HAVING SUM(CASE WHEN column_name LIKE 't_basket' THEN 1 ELSE 0 END) = 0;
+    """)
+    tables=cursor.fetchall()
+    for tbl in tables:
+        cursor.execute(f"""
+    	ALTER TABLE tww_od.{tablename} ADD COLUMN IF NOT EXISTS t_basket INTEGER,
+        CONSTRAINT fkey_od_{tablename}_t_basket FOREIGN KEY (t_basket)
+        REFERENCES tww_sys.oid_prefixes (id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE SET NULL;
+        """)
+    conn.commit()
+    conn.close()
+
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("-p", "--pg_service", help="postgres service")
+
+    args = parser.parse_args()
+
+    create_od_baskets(
+        args.srid,
+    )

--- a/datamodel/create_baskets.py
+++ b/datamodel/create_baskets.py
@@ -24,12 +24,12 @@ def create_od_baskets(pg_service: str):
     for tbl in tables:
         cursor.execute(
             f"""
-    	ALTER TABLE tww_od.{tablename} ADD COLUMN IF NOT EXISTS t_basket INTEGER,
-        CONSTRAINT fkey_od_{tablename}_t_basket FOREIGN KEY (t_basket)
-        REFERENCES tww_sys.oid_prefixes (id) MATCH SIMPLE
-        ON UPDATE CASCADE
-        ON DELETE SET NULL;
-        """
+                ALTER TABLE tww_od.{tbl} ADD COLUMN IF NOT EXISTS t_basket INTEGER,
+                CONSTRAINT fkey_od_{tbl}_t_basket FOREIGN KEY (t_basket)
+                REFERENCES tww_sys.oid_prefixes (id) MATCH SIMPLE
+                ON UPDATE CASCADE
+                ON DELETE SET NULL;
+            """
         )
     conn.commit()
     conn.close()

--- a/datamodel/create_baskets.py
+++ b/datamodel/create_baskets.py
@@ -7,29 +7,32 @@ try:
 except ImportError:
     import psycopg2 as psycopg
 
-    
+
 def create_od_baskets(pg_service: str):
     conn = psycopg.connect(f"service={pg_service}")
     cursor = conn.cursor()
-    cursor.execute("""
+    cursor.execute(
+        """
         SELECT table_name
-        FROM information_schema.columns 
+        FROM information_schema.columns
         WHERE table_schema = 'tww_od'
         GROUP BY table_name
         HAVING SUM(CASE WHEN column_name LIKE 't_basket' THEN 1 ELSE 0 END) = 0;
-    """)
-    tables=cursor.fetchall()
+    """
+    )
+    tables = cursor.fetchall()
     for tbl in tables:
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
     	ALTER TABLE tww_od.{tablename} ADD COLUMN IF NOT EXISTS t_basket INTEGER,
         CONSTRAINT fkey_od_{tablename}_t_basket FOREIGN KEY (t_basket)
         REFERENCES tww_sys.oid_prefixes (id) MATCH SIMPLE
         ON UPDATE CASCADE
         ON DELETE SET NULL;
-        """)
+        """
+        )
     conn.commit()
     conn.close()
-
 
 
 if __name__ == "__main__":

--- a/datamodel/scripts/setup.sh
+++ b/datamodel/scripts/setup.sh
@@ -37,4 +37,5 @@ psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/changelogs/0001/52_dss1
 psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_0_roles.sql
 psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_1_roles.sql
 
+${DIR}/create_baskets.py --pg_service ${PGSERVICE}
 ${DIR}/app/create_app.py --pg_service ${PGSERVICE} --srid ${SRID}

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -187,12 +187,12 @@ class DatabaseUtils:
             msg_list.append(
                 "OID prefix cannot be set because the default basket is not defined. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
             )
-            
+
         elif len(prefixes) > 1: # only possible if someone tampered with the database
             msg_list.append(
                 "OID prefix cannot be set because the multiple baskets are defined for the current user. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
             )
-            
+
         if len(prefixes) > 0:
             active_pref = prefixes[0][0]
             if active_pref == "ch000000":

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -175,12 +175,14 @@ class DatabaseUtils:
         """Check whether the oid_prefix is set up for production"""
         logger.info("Checking setup of oid prefix")
         pgconf = DatabaseUtils.get_pgconf()
-        current_usr=pgconf['user']
-        prefixes = DatabaseUtils.fetchall(f"""
+        current_usr = pgconf["user"]
+        prefixes = DatabaseUtils.fetchall(
+            f"""
             SELECT prefix FROM tww_sys.oid_prefixes pf
             LEFT JOIN tww_od.oid_manager om on om.t_basket =pf.id
             WHERE ub.usr_name='{current_usr}';
-            """)
+            """
+        )
 
         msg_list = []
         if len(prefixes) == 0:
@@ -188,7 +190,7 @@ class DatabaseUtils:
                 "OID prefix cannot be set because the default basket is not defined. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
             )
 
-        elif len(prefixes) > 1: # only possible if someone tampered with the database
+        elif len(prefixes) > 1:  # only possible if someone tampered with the database
             msg_list.append(
                 "OID prefix cannot be set because the multiple baskets are defined for the current user. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
             )

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -183,7 +183,7 @@ class DatabaseUtils:
             """)
 
         msg_list = []
-        if len(prefixes) = 0:
+        if len(prefixes) == 0:
             msg_list.append(
                 "OID prefix cannot be set because the default basket is not defined. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
             )

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -174,14 +174,25 @@ class DatabaseUtils:
     def check_oid_prefix() -> List[str]:
         """Check whether the oid_prefix is set up for production"""
         logger.info("Checking setup of oid prefix")
-        prefixes = DatabaseUtils.fetchall("SELECT prefix FROM tww_sys.oid_prefixes WHERE active;")
+        pgconf = DatabaseUtils.get_pgconf()
+        current_usr=pgconf['user']
+        prefixes = DatabaseUtils.fetchall(f"""
+            SELECT prefix FROM tww_sys.oid_prefixes pf
+            LEFT JOIN tww_od.oid_manager om on om.t_basket =pf.id
+            WHERE ub.usr_name='{current_usr}';
+            """)
 
         msg_list = []
-        if len(prefixes) > 1:
+        if len(prefixes) = 0:
             msg_list.append(
-                "more than one oid_prefix set to active. Generation of Object-ID will not work. Set the OID prefix for your production database to active."
+                "OID prefix cannot be set because the default basket is not defined. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
             )
-
+            
+        elif len(prefixes) > 1: # only possible if someone tampered with the database
+            msg_list.append(
+                "OID prefix cannot be set because the multiple baskets are defined for the current user. Generation of Object-ID will not work. Add your user to tww_od.oid_manager and set a basket."
+            )
+            
         if len(prefixes) > 0:
             active_pref = prefixes[0][0]
             if active_pref == "ch000000":


### PR DESCRIPTION
For offices that are managing multiple communities, it is beneficial to be able to treat all wastewater data in one database. This PR makes a first step into that direction.

To do:

- [ ] sequence handling
- [ ] filtering per basket on export
- [ ] directing import to specific basket
- [ ] filtering per basket in project
- [ ] GUI to alter current basket