### PR TITLE
Do not insert all oid prefixes on db creation level

### DIFF
--- a/datamodel/changelogs/0001/oid_generation.sql
+++ b/datamodel/changelogs/0001/oid_generation.sql
@@ -19,15 +19,7 @@ COMMENT ON TABLE tww_sys.oid_prefixes
 
 -- sample entry for Invalid - you need to adapt this entry later for your own organization
 INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch000000','Invalid',TRUE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch11h8mw','Stadt Uster',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch15z36d','SIGE',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch13p7mz','Arbon',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch176dc9','Sigip',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch17f516','Prilly',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch17nq5g','Triform',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch2003p6','Vevey',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch238z74','La Tour-de-Peilz',FALSE);
-INSERT INTO tww_sys.oid_prefixes (prefix,organization,active) VALUES ('ch234hqx','BTI',FALSE);
+
 
 CREATE INDEX in_tww_is_oid_prefixes_active
   ON tww_sys.oid_prefixes


### PR DESCRIPTION
## General
 - [x] Fix a bug

### Context
It is not a good practice to store the oid prefixes in the main datamodel. The sysadmin should add their own prefixes to their datbase instead

## Describe your changes
Remove provided oid prefixes

## Screenshots

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CI Tests are green
- [ ] The documentation is up to date with the proposed change.
- [ ] My work is ready for review

## Checklist before merge
- [ ] A review has been performed
- [ ] Comments are resolved
- [ ] Documentation is ready
