### PR TITLE
move reach points when vw_tww_wastewater_structure is moved

### DIFF
--- a/datamodel/app/view/vw_tww_wastewater_structure.py
+++ b/datamodel/app/view/vw_tww_wastewater_structure.py
@@ -448,6 +448,19 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
           SELECT obj_id FROM tww_od.wastewater_networkelement
           WHERE fk_wastewater_structure = NEW.obj_id
         );
+        
+        -- Move reach point node as well
+        UPDATE tww_od.reach_point RP
+        SET situation3d_geometry = ST_SetSRID( ST_MakePoint(
+        ST_X(ST_TRANSLATE(ST_MakePoint(ST_X(RP.situation3d_geometry), ST_Y(RP.situation3d_geometry)), dx, dy )),
+        ST_Y(ST_TRANSLATE(ST_MakePoint(ST_X(RP.situation3d_geometry), ST_Y(RP.situation3d_geometry)), dx, dy )),
+        ST_Z(RP.situation3d_geometry)), {srid} )
+        WHERE obj_id IN
+        (
+          SELECT RP.obj_id FROM tww_od.reach_point RP
+          LEFT JOIN tww_od.wastewater_networkelement NE ON RP.fk_wastewater_networkelement = NE.obj_id
+          WHERE NE.fk_wastewater_structure = NEW.obj_id
+        );
 
         -- Move covers
         UPDATE tww_od.cover CO

--- a/datamodel/app/view/vw_tww_wastewater_structure.py
+++ b/datamodel/app/view/vw_tww_wastewater_structure.py
@@ -448,7 +448,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
           SELECT obj_id FROM tww_od.wastewater_networkelement
           WHERE fk_wastewater_structure = NEW.obj_id
         );
-        
+
         -- Move reach point node as well
         UPDATE tww_od.reach_point RP
         SET situation3d_geometry = ST_SetSRID( ST_MakePoint(


### PR DESCRIPTION
as mentioned in #313, reach points should be moved when a vw_tww_wastewater_structure is moved. This PR does not alter the project file