### PR TITLE
add Linking Relation Editor and Document Management System to plugin …

### DIFF
--- a/plugin/teksi_wastewater/metadata.txt
+++ b/plugin/teksi_wastewater/metadata.txt
@@ -19,5 +19,7 @@ changelog=https://github.com/teksi/wastewater/releases
 
 icon=icons/teksi-abwasser-logo.svg
 
+plugin_dependencies=Linking Relation Editor, Document Management System
+
 experimental=False
 deprecated=False


### PR DESCRIPTION
…dependencies

We use both the LRE and the DMS in our forms. By adding them as a dependency, we ensure they are loaded