### PR TITLE
Fix updating of fk_main_wastewater_node/fk_main_cover

### DIFF
--- a/datamodel/app/symbology_functions.sql
+++ b/datamodel/app/symbology_functions.sql
@@ -289,7 +289,7 @@ LANGUAGE plpgsql VOLATILE;
 --------------------------------------------------------
 -- UPDATE wastewater structure fk_main_cover
 -- Argument:
---  * obj_id of wastewater structure
+--  * obj_id of wastewater structure. No change if fk_main_cover is not null
 --  * all True to update all
 --  * omit both arguments to update all where fk_main_cover is null
 --------------------------------------------------------
@@ -308,7 +308,7 @@ BEGIN
       LEFT JOIN tww_od.structure_part sp ON sp.fk_wastewater_structure = ws.obj_id
       LEFT JOIN tww_od.cover co ON sp.obj_id = co.obj_id
       LEFT JOIN tww_od.channel ch ON ch.obj_id = ws.obj_id
-      WHERE ch.obj_id IS NULL AND (_all OR ws.obj_id = _obj_id OR ( NOT _all AND _obj_id is NULL AND ws.fk_main_cover IS NULL))
+      WHERE ch.obj_id IS NULL AND (_all OR ((ws.obj_id = _obj_id OR (NOT _all AND _obj_id is NULL)) AND ws.fk_main_cover IS NULL))
   ) ws_covers
   WHERE ws.obj_id = ws_covers.obj_id;
 END
@@ -320,7 +320,7 @@ VOLATILE;
 --------------------------------------------------------
 -- UPDATE wastewater structure fk_main_wastewater_node
 -- Argument:
---  * obj_id of wastewater structure
+--  * obj_id of wastewater structure. No change if fk_main_wastewater_node is not null
 --  * all True to update all
 --  * omit both arguments to update all where fk_main_wastewater_node is null
 --------------------------------------------------------
@@ -340,7 +340,7 @@ BEGIN
       LEFT JOIN tww_od.wastewater_networkelement ne ON ne.fk_wastewater_structure = ws.obj_id
       LEFT JOIN tww_od.wastewater_node wn ON ne.obj_id = wn.obj_id
       LEFT JOIN tww_od.channel ch ON ch.obj_id = ws.obj_id
-      WHERE ch.obj_id IS NULL AND (_all OR ws.obj_id = _obj_id OR ( NOT _all AND _obj_id is NULL AND ws.fk_main_wastewater_node IS NULL))
+      WHERE ch.obj_id IS NULL AND (_all OR ((ws.obj_id = _obj_id OR (NOT _all AND _obj_id is NULL)) AND ws.fk_main_wastewater_node IS NULL))
   ) ws_nodes
   WHERE ws.obj_id = ws_nodes.obj_id;
 END


### PR DESCRIPTION
When creating the functions ` tww_app.wastewater_structure_update_fk_main_wastewater_node` / `tww_app.wastewater_structure_update_fk_main_cover`, the idea was to call them only in obj_id mode if a structure has no fk_main_wastewater_node/fk_main_cover. 

Now, we intend to use them in trigger functions regardless whether the `fk_main_wastewater_node`/`fk_main_cover` is NULL or not. This poses a problem as the function sets the `fk_main_xxx` to the min value of all cover/node oids linked to the wastewater structure.  If I have a main cover that has a higher OID than a secondary one, the triggers will overwrite that setting on wastewater structure when altering any cover attribute. 

To mitigate that problem,when calling `tww_app.wastewater_structure_update_fk_main_xxx(obj_id)`  we now only update the main cover/wastewater_node if the value is NULL. Calling `tww_app.wastewater_structure_update_fk_main_xxx(NULL)` continues to set it for all where fk_main_xxx is NULL, calling `tww_app.wastewater_structure_update_fk_main_xxx(NULL,true)` overwrites the fk_main_xx for all entries 