### PR TITLE
Allow SSL params for Auth

### DIFF
--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -38,26 +38,26 @@ def get_pgconf_as_ili_args() -> List[str]:
     args = []
     dbparams = []
     for key in pgconf:
-        if key=="host":
+        if key == "host":
             args.extend(["--dbhost", '"' + pgconf["host"] + '"'])
-        elif key=="port":
+        elif key == "port":
             args.extend(["--dbport", '"' + pgconf["port"] + '"'])
-        elif key=="user":
+        elif key == "user":
             args.extend(["--dbusr", '"' + pgconf["user"] + '"'])
-        elif key=="password":
+        elif key == "password":
             args.extend(["--dbpwd", '"' + pgconf["password"] + '"'])
-        elif key=="dbname":
+        elif key == "dbname":
             args.extend(["--dbdatabase", '"' + pgconf["dbname"] + '"'])
         else:
-            dbparams.extend([f'{key}={pgconf[key]}'])
+            dbparams.extend([f"{key}={pgconf[key]}"])
     if dbparams:
         # write into tempfile and add path to args
-        dbparams_path=os.path.join(tempfile.gettempdir(), "dbparams")
+        dbparams_path = os.path.join(tempfile.gettempdir(), "dbparams")
         os.makedirs(dbparams_path, exist_ok=True)
-        with open(os.path.join(dbparams_path,"dbparams.txt"),"w") as f:
+        with open(os.path.join(dbparams_path, "dbparams.txt"), "w") as f:
             for param in dbparams:
-                f.write(param+"\n")
-        args.extend(["--dbparams", '"' + os.path.join(dbparams_path,"dbparams.txt") + '"'])
+                f.write(param + "\n")
+        args.extend(["--dbparams", '"' + os.path.join(dbparams_path, "dbparams.txt") + '"'])
     return args
 
 

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -36,16 +36,28 @@ def get_pgconf_as_ili_args() -> List[str]:
     """Returns the pgconf as a list of ili2db arguments"""
     pgconf = DatabaseUtils.get_pgconf()
     args = []
-    if pgconf["host"]:
-        args.extend(["--dbhost", '"' + pgconf["host"] + '"'])
-    if pgconf["port"]:
-        args.extend(["--dbport", '"' + pgconf["port"] + '"'])
-    if pgconf["user"]:
-        args.extend(["--dbusr", '"' + pgconf["user"] + '"'])
-    if pgconf["password"]:
-        args.extend(["--dbpwd", '"' + pgconf["password"] + '"'])
-    if pgconf["dbname"]:
-        args.extend(["--dbdatabase", '"' + pgconf["dbname"] + '"'])
+    dbparams = []
+    for key in pgconf:
+        if key=="host":
+            args.extend(["--dbhost", '"' + pgconf["host"] + '"'])
+        elif key=="port":
+            args.extend(["--dbport", '"' + pgconf["port"] + '"'])
+        elif key=="user":
+            args.extend(["--dbusr", '"' + pgconf["user"] + '"'])
+        elif key=="password":
+            args.extend(["--dbpwd", '"' + pgconf["password"] + '"'])
+        elif key=="dbname":
+            args.extend(["--dbdatabase", '"' + pgconf["dbname"] + '"'])
+        else:
+            dbparams.extend([f'{key}={pgconf[key]}'])
+    if dbparams:
+        # write into tempfile and add path to args
+        dbparams_path=os.path.join(tempfile.gettempdir(), "dbparams")
+        os.makedirs(dbparams_path, exist_ok=True)
+        with open(os.path.join(dbparams_path,"dbparams.txt"),"w") as f:
+            for param in dbparams:
+                f.write(param+"\n")
+        args.extend(["--dbparams", '"' + os.path.join(dbparams_path,"dbparams.txt") + '"'])
     return args
 
 

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -3,8 +3,8 @@ import os
 import re
 import subprocess
 import tempfile
-from typing import List
 import uuid
+from typing import List
 
 from ...utils.database_utils import DatabaseUtils
 from ...utils.plugin_utils import logger

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -58,6 +58,8 @@ def get_pgconf_as_ili_args() -> List[str]:
             for param in dbparams:
                 f.write(param + "\n")
         args.extend(["--dbparams", '"' + os.path.join(dbparams_path, "dbparams.txt") + '"'])
+    if not pgconf["user"]:
+        args.extend(["--dbusr", '"' + os.getenv("USERNAME") + '"'])
     return args
 
 

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -5,7 +5,9 @@ import subprocess
 import tempfile
 import uuid
 from typing import List
+
 from qgis.core import QgsExpression
+
 from ...utils.database_utils import DatabaseUtils
 from ...utils.plugin_utils import logger
 
@@ -61,7 +63,7 @@ def get_pgconf_as_ili_args() -> List[str]:
         args.extend(["--dbparams", '"' + os.path.join(dbparams_path, "dbparams.txt") + '"'])
     if not pgconf["user"]:
         # allow loading PGUSER from overriden env variables
-        expression = QgsExpression('@PGUSER')
+        expression = QgsExpression("@PGUSER")
         pguser = expression.evaluate()
         args.extend(["--dbusr", f'"{pguser}"'])
     return args

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import uuid
 from typing import List
-
+from qgis.core import QgsExpression
 from ...utils.database_utils import DatabaseUtils
 from ...utils.plugin_utils import logger
 
@@ -60,7 +60,10 @@ def get_pgconf_as_ili_args() -> List[str]:
                 f.write(param + "\n")
         args.extend(["--dbparams", '"' + os.path.join(dbparams_path, "dbparams.txt") + '"'])
     if not pgconf["user"]:
-        args.extend(["--dbusr", '"' + os.getenv("USERNAME") + '"'])
+        # allow loading PGUSER from overriden env variables
+        expression = QgsExpression('@PGUSER')
+        pguser = expression.evaluate()
+        args.extend(["--dbusr", f'"{pguser}"'])
     return args
 
 

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import tempfile
 from typing import List
+import uuid
 
 from ...utils.database_utils import DatabaseUtils
 from ...utils.plugin_utils import logger
@@ -52,7 +53,7 @@ def get_pgconf_as_ili_args() -> List[str]:
             dbparams.extend([f"{key}={pgconf[key]}"])
     if dbparams:
         # write into tempfile and add path to args
-        dbparams_path = os.path.join(tempfile.gettempdir(), "dbparams")
+        dbparams_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
         os.makedirs(dbparams_path, exist_ok=True)
         with open(os.path.join(dbparams_path, "dbparams.txt"), "w") as f:
             for param in dbparams:

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -133,7 +133,7 @@ class DatabaseUtils:
         pgconf = DatabaseUtils.get_pgconf()
         parts = []
         for key in pgconf:
-            parts.append(f'{key}={pgconf[key]}')
+            parts.append(f"{key}={pgconf[key]}")
         return " ".join(parts)
 
     @staticmethod

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -132,16 +132,8 @@ class DatabaseUtils:
 
         pgconf = DatabaseUtils.get_pgconf()
         parts = []
-        if pgconf["host"]:
-            parts.append(f"host={pgconf['host']}")
-        if pgconf["port"]:
-            parts.append(f"port={pgconf['port']}")
-        if pgconf["user"]:
-            parts.append(f"dbname={pgconf['dbname']}")
-        if pgconf["password"]:
-            parts.append(f"user={pgconf['user']}")
-        if pgconf["dbname"]:
-            parts.append(f"password={pgconf['password']}")
+        for key in pgconf:
+            parts.append(f'{key}={pgconf[key]}')
         return " ".join(parts)
 
     @staticmethod


### PR DESCRIPTION
This PR aims to fix the problems in #393. Now. all parameters in the pg_service entry are evaluated by the plugin. When using INTERLIS-Import/Export, all values that are not host/port/database/user/password are stored in a temporary dbparams file for usage in ili2pg. 

The main problem I have now is that that SSL-keys must be in DER format to be used in ili2pg, but QGIS requires PEM. Everything except INTERLIS works with SSL. See https://github.com/claeis/ili2db/issues/551 for upstream issue