### PR TITLE
disable modification triggers when updating all symbologies

### DIFF
--- a/datamodel/app/functions/symbology_functions.sql
+++ b/datamodel/app/functions/symbology_functions.sql
@@ -67,8 +67,9 @@ BEGIN
 -- Otherwise this will result in very slow query due to on_structure_part_change_networkelement
 -- being triggered for all rows. See https://github.com/QGEP/datamodel/pull/166#issuecomment-760245405 //skip-keyword-check
 IF _all THEN
-  RAISE INFO 'Temporarily disabling symbology triggers';
+  RAISE INFO 'Temporarily disabling symbology and modification triggers';
   PERFORM tww_app.alter_symbology_triggers('disable');
+  PERFORM tww_app.alter_modification_triggers('disable');
 END IF;
 
 
@@ -122,8 +123,9 @@ EXECUTE tww_app.update_wn_symbology_by_overflow(_obj_id, _all);
 
 -- See above
 IF _all THEN
-  RAISE INFO 'Reenabling symbology triggers';
+  RAISE INFO 'Reenabling symbology and modification triggers';
   PERFORM tww_app.alter_symbology_triggers('enable');
+  PERFORM tww_app.alter_modification_triggers('enable');
 END IF;
 
 END
@@ -145,8 +147,9 @@ BEGIN
 -- Otherwise this will result in very slow query due to on_structure_part_change_networkelement
 -- being triggered for all rows. See https://github.com/QGEP/datamodel/pull/166#issuecomment-760245405 //skip-keyword-check
 IF _all THEN
-  RAISE INFO 'Temporarily disabling symbology triggers';
+  RAISE INFO 'Temporarily disabling symbology and modification triggers';
   PERFORM tww_app.alter_symbology_triggers('disable');
+  PERFORM tww_app.alter_modification_triggers('disable');
 END IF;
 
 
@@ -191,6 +194,7 @@ WHERE symbology_ne.wn_obj_id = n.obj_id
 IF _all THEN
   RAISE INFO 'Reenabling symbology triggers';
   PERFORM tww_app.alter_symbology_triggers('enable');
+  PERFORM tww_app.alter_modification_triggers('enable');
 END IF;
 
 END


### PR DESCRIPTION
When updating the symbologies, it is faster to disable the last_modification triggers. We do not alter the base data, but only update dependencies. Also, when adding other modification triggers such as in agxx, these need to be turned off temporarily.