### PR TITLE
prioritise discharged_wastewater in symbology

### DIFF
--- a/datamodel/app/functions/symbology_functions.sql
+++ b/datamodel/app/functions/symbology_functions.sql
@@ -110,7 +110,7 @@ FROM(
 
     WHERE _all OR wn.obj_id = _obj_id
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier_to.tww_symbology_inflow_prio NULLS LAST
+                    ORDER BY coalesce(vl_fct_hier_to.tww_symbology_inflow_prio,false) DESC
 						   , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_to.tww_symbology_order ASC NULLS LAST
 
@@ -179,7 +179,7 @@ FROM(
       LEFT JOIN tww_vl.channel_usage_current       vl_usg_curr_from	ON wn_from._usage_current = vl_usg_curr_from.code
 	  WHERE (_all OR wn.obj_id = _obj_id)
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier.tww_symbology_inflow_prio NULLS LAST
+                    ORDER BY coalesce(vl_fct_hier.tww_symbology_inflow_prio,false) DESC
 						   , vl_fct_hier.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
 

--- a/datamodel/app/functions/symbology_functions.sql
+++ b/datamodel/app/functions/symbology_functions.sql
@@ -110,7 +110,8 @@ FROM(
 
     WHERE _all OR wn.obj_id = _obj_id
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
+                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology 
+						   , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_to.tww_symbology_order ASC NULLS LAST
 
                            , vl_usg_curr_from.tww_symbology_order ASC NULLS LAST
@@ -178,7 +179,8 @@ FROM(
       LEFT JOIN tww_vl.channel_usage_current       vl_usg_curr_from	ON wn_from._usage_current = vl_usg_curr_from.code
 	  WHERE (_all OR wn.obj_id = _obj_id)
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier.tww_symbology_order ASC NULLS LAST
+                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology 
+						   , vl_fct_hier.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
 
                            , vl_usg_curr.tww_symbology_order ASC NULLS LAST

--- a/datamodel/app/functions/symbology_functions.sql
+++ b/datamodel/app/functions/symbology_functions.sql
@@ -110,7 +110,7 @@ FROM(
 
     WHERE _all OR wn.obj_id = _obj_id
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology 
+                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology
 						   , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_to.tww_symbology_order ASC NULLS LAST
 
@@ -179,7 +179,7 @@ FROM(
       LEFT JOIN tww_vl.channel_usage_current       vl_usg_curr_from	ON wn_from._usage_current = vl_usg_curr_from.code
 	  WHERE (_all OR wn.obj_id = _obj_id)
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology 
+                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology
 						   , vl_fct_hier.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
 

--- a/datamodel/app/functions/symbology_functions.sql
+++ b/datamodel/app/functions/symbology_functions.sql
@@ -179,7 +179,7 @@ FROM(
       LEFT JOIN tww_vl.channel_usage_current       vl_usg_curr_from	ON wn_from._usage_current = vl_usg_curr_from.code
 	  WHERE (_all OR wn.obj_id = _obj_id)
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology
+                    ORDER BY vl_fct_hier.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology
 						   , vl_fct_hier.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
 

--- a/datamodel/app/functions/symbology_functions.sql
+++ b/datamodel/app/functions/symbology_functions.sql
@@ -110,7 +110,7 @@ FROM(
 
     WHERE _all OR wn.obj_id = _obj_id
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier_to.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology
+                    ORDER BY vl_fct_hier_to.tww_symbology_inflow_prio NULLS LAST
 						   , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_to.tww_symbology_order ASC NULLS LAST
 
@@ -179,7 +179,7 @@ FROM(
       LEFT JOIN tww_vl.channel_usage_current       vl_usg_curr_from	ON wn_from._usage_current = vl_usg_curr_from.code
 	  WHERE (_all OR wn.obj_id = _obj_id)
       WINDOW w AS ( PARTITION BY wn.obj_id
-                    ORDER BY vl_fct_hier.code = 4516 DESC NULLS LAST --prioritise discharged_wastewater in symbology
+                    ORDER BY vl_fct_hier.tww_symbology_inflow_prio NULLS LAST
 						   , vl_fct_hier.tww_symbology_order ASC NULLS LAST
                            , vl_fct_hier_from.tww_symbology_order ASC NULLS LAST
 

--- a/datamodel/changelogs/0001/05_data_model_extensions.sql
+++ b/datamodel/changelogs/0001/05_data_model_extensions.sql
@@ -54,6 +54,11 @@ ALTER TABLE tww_vl.channel_function_hierarchic ADD COLUMN tww_use_in_labels bool
 UPDATE tww_vl.channel_function_hierarchic
 SET tww_use_in_labels= true WHERE value_en like 'pwwf%';
 
+-- this column is an extension to the VSA data model defines which function_hierarchic to use in labels
+ALTER TABLE tww_vl.channel_function_hierarchic ADD COLUMN tww_symbology_inflow_prio bool DEFAULT false;
+UPDATE tww_vl.channel_function_hierarchic
+SET tww_symbology_inflow_prio= true WHERE code =4516;
+
 
 -- integrate and adapt Alter order_fct_hierarchic in tww_vl.channel_function_hierarchic #224
 -- https://github.com/QGEP/datamodel/pull/224 //skip-keyword-check


### PR DESCRIPTION
Usually, the node symbology works fine by prioritising the outgoing channel over incoming channels. However, when discharged wastewater flows into a culverted water body (eigedoltes Gewässer), it is preferrable to use the discharged wastewater usage for symbology.