### PR TITLE
Fixes to MultipleInheritances

### DIFF
--- a/datamodel/app/create_app.py
+++ b/datamodel/app/create_app.py
@@ -150,9 +150,7 @@ def create_app(
 
     MultipleInheritance(
         safe_load(open(cwd / "view/vw_maintenance_event.yaml")),
-        create_joins=True,
         drop=True,
-        variables=variables,
         pg_service=pg_service,
     ).create()
 

--- a/datamodel/app/create_app.py
+++ b/datamodel/app/create_app.py
@@ -173,7 +173,6 @@ def create_app(
 
     MultipleInheritance(
         safe_load(open(cwd / "view/vw_oo_overflow.yaml")),
-        create_joins=True,
         variables=variables,
         pg_service=pg_service,
         drop=True,

--- a/datamodel/app/view/vw_maintenance_event.yaml
+++ b/datamodel/app/view/vw_maintenance_event.yaml
@@ -2,7 +2,7 @@
 table: tww_od.maintenance_event
 view_name: vw_tww_maintenance_event
 view_schema: tww_app
-allow_type_change: false
+allow_type_change: true
 allow_parent_only: false
 pkey_default_value: True
 

--- a/datamodel/app/view/vw_oo_overflow.yaml
+++ b/datamodel/app/view/vw_oo_overflow.yaml
@@ -7,7 +7,7 @@ allow_parent_only: false
 pkey_default_value: True
 
 additional_columns:
-  geometry: n1.situation3d_geometry::geometry('PointZ',{SRID})
+  geometry: n1.situation3d_geometry
 additional_joins: >
   LEFT JOIN tww_od.wastewater_node n1 ON overflow.fk_wastewater_node::text = n1.obj_id::text
 


### PR DESCRIPTION
## General
 - [x] Fix a bug

## Describe your changes
- With the grouping of all SimpleJoins in #116, the multipleInheritances created their SimpleInheritance views in od (using od as a fallback as the views already existed in app). This PR changes that
- allow type change on vw_tww_maintenance_event (useful when manually creating)
- remove type cast for vw_tww_overflow geometry (not necessary)

## To-Do

## Screenshots

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests. (not needed)
- [X] CI Tests are green
- [x] The documentation is up to date with the proposed change. (not needed)
- [X] My work is ready for review

## Checklist before merge
- [ ] A review has been performed
- [ ] Comments are resolved
- [ ] Documentation is ready