### PR TITLE
Prevent view crashing if `ST_LENGTH(re.progression3d_geometry)` is null or 0

### DIFF
--- a/datamodel/app/view/vw_tww_reach.py
+++ b/datamodel/app/view/vw_tww_reach.py
@@ -47,7 +47,7 @@ def vw_tww_reach(pg_service: str = None, extra_definition: dict = None):
           ELSE clear_height
         END AS width,
         CASE
-          WHEN rp_from.level > 0 AND rp_to.level > 0 THEN round((rp_from.level - rp_to.level)/ST_LENGTH(re.progression3d_geometry)::numeric*1000,1)
+          WHEN rp_from.level > 0 AND rp_to.level > 0 AND ST_LENGTH(re.progression3d_geometry) IS NOT NULL AND ST_LENGTH(re.progression3d_geometry) > 0 THEN round((rp_from.level - rp_to.level)/ST_LENGTH(re.progression3d_geometry)::numeric*1000,1)
           ELSE NULL
         END AS _slope_per_mill
         , {extra_cols}

--- a/datamodel/app/view/vw_tww_reach.py
+++ b/datamodel/app/view/vw_tww_reach.py
@@ -47,7 +47,7 @@ def vw_tww_reach(pg_service: str = None, extra_definition: dict = None):
           ELSE clear_height
         END AS width,
         CASE
-          WHEN rp_from.level > 0 AND rp_to.level > 0 AND ST_LENGTH(re.progression3d_geometry) IS NOT NULL AND ST_LENGTH(re.progression3d_geometry) > 0 THEN round((rp_from.level - rp_to.level)/ST_LENGTH(re.progression3d_geometry)::numeric*1000,1)
+          WHEN rp_from.level > 0 AND rp_to.level > 0 THEN ROUND((rp_from.level - rp_to.level) / NULLIF(ST_LENGTH(re.progression3d_geometry)::numeric, 0) * 1000, 1)
           ELSE NULL
         END AS _slope_per_mill
         , {extra_cols}


### PR DESCRIPTION
## General
 - [x] Fix a bug

## Describe your changes
Prevent view `vw_tww_reach` from crashing if ST_LENGTH(re.progression3d_geometry) is null or 0

## Screenshots

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] CI Tests are green
- [x] The documentation is up to date with the proposed change.
- [x] My work is ready for review

## Checklist before merge
- [x] A review has been performed
- [x] Comments are resolved
- [x] Documentation is ready
