### PR TITLE
Add flag to initialise prefix path on interlis cmd

### DIFF
--- a/plugin/tww_cmd.py
+++ b/plugin/tww_cmd.py
@@ -25,6 +25,11 @@ class TeksiWastewaterCmd:
         self.parser = argparse.ArgumentParser()
         self.args = None
 
+        self.parser.add_argument(
+            "--qgs_app_prefix_path",
+            help="QGIS Application prefix path",
+        )        
+
         subparsers = self.parser.add_subparsers(dest="subparser_name", help="sub-command --help")
 
         self._add_subparser_interlis_import(subparsers=subparsers)
@@ -155,7 +160,10 @@ class TeksiWastewaterCmd:
             exit(1)
 
     def execute_interlis_import(self):
+        if self.args.qgs_app_prefix_path:
+            QgsApplication.setPrefixPath(self.args.qgs_app_prefix_path, True)
         qgs = QgsApplication([], False)
+        qgs.initQgis()
 
         DatabaseUtils.databaseConfig.PGSERVICE = self.args.pgservice
         DatabaseUtils.databaseConfig.PGHOST = self.args.pghost
@@ -189,7 +197,10 @@ class TeksiWastewaterCmd:
         qgs.exitQgis()
 
     def execute_interlis_export(self):
+        if self.args.qgs_app_prefix_path:
+            QgsApplication.setPrefixPath(self.args.qgs_app_prefix_path, True)
         qgs = QgsApplication([], False)
+        qgs.initQgis()
 
         DatabaseUtils.databaseConfig.PGSERVICE = self.args.pgservice
         DatabaseUtils.databaseConfig.PGHOST = self.args.pghost

--- a/plugin/tww_cmd.py
+++ b/plugin/tww_cmd.py
@@ -28,7 +28,7 @@ class TeksiWastewaterCmd:
         self.parser.add_argument(
             "--qgs_app_prefix_path",
             help="QGIS Application prefix path",
-        )        
+        )
 
         subparsers = self.parser.add_subparsers(dest="subparser_name", help="sub-command --help")
 


### PR DESCRIPTION
For usage in standalone scripts, we should initialize the application path. See **https://docs.qgis.org/3.40/en/docs/pyqgis_developer_cookbook/intro.html#using-pyqgis-in-standalone-scripts**