### PR TITLE
Fix type 'unknown' handling for vw_tww_wastewater_structure

### DIFF
--- a/datamodel/app/view/vw_tww_wastewater_structure.py
+++ b/datamodel/app/view/vw_tww_wastewater_structure.py
@@ -413,12 +413,16 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
           BEGIN
             EXECUTE FORMAT({literal_delete_on_ws_change});
           END;
+        ELSE -- do nothing
+          NULL;
         END CASE;
 
         CASE WHEN NEW.ws_type = ANY(ARRAY['manhole','special_structure','discharge_point','infiltration_installation','drainless_toilet','wwtp_structure','small_treatment_plant']) THEN
           BEGIN
             EXECUTE FORMAT({literal_insert_on_ws_change});
           END;
+        ELSE -- do nothing
+          NULL;
         END CASE;
       END IF;
 
@@ -436,6 +440,7 @@ def vw_tww_wastewater_structure(srid: int, pg_service: str = None, extra_definit
           {update_ii}
 
         ELSE -- do nothing
+          NULL;
       END CASE;
 
       -- Cover geometry has been moved


### PR DESCRIPTION
When updating a wastewater structure with no subclass or a subclass that is not handled by vw_tww_wastewater_structure, the update fails due to lacking `ELSE NULL;` clauses. This PR fixes that