### PR TITLE
reload audited tables and update od from 2024_0_5 to 2025_0_1

### DIFF
--- a/datamodel/.pum.yaml
+++ b/datamodel/.pum.yaml
@@ -64,7 +64,7 @@ dependencies:
 
 migration_hooks:
   pre:
-    - code: DROP SCHEMA IF EXISTS tww_app CASCADE;
+    - file: ./pre_migration.sql
   post:
     - file: app/create_app.py
 

--- a/datamodel/app/audit/reinsert_audit_triggers.sql
+++ b/datamodel/app/audit/reinsert_audit_triggers.sql
@@ -1,0 +1,32 @@
+DO
+$DO$
+DECLARE 
+	rel_record record;
+BEGIN
+	FOR rel_record  in 
+		SELECT 
+			split_part(relation_name, '.', 1) as schm,
+			split_part(relation_name, '.', 2) as rel,
+			uid_column FROM tww_sys.logged_relations 
+	LOOP
+		SELECT EXISTS (
+            SELECT 1
+            FROM pg_tables
+            WHERE schemaname = rel_record.schm
+            AND tablename = rel_record.rel
+        ) INTO is_table;
+		IF is_table THEN
+            EXECUTE FORMAT( 'SELECT tww_app.audit_table(''%I.%I'')', rel_record.schm, rel_record.rel);
+            -- Do something for tables
+        ELSE
+            EXECUTE 
+				FORMAT( 'SELECT tww_app.audit_view(''%I.%I'', true, ''{}''::text[], ''{%I}''::text[])'
+				, rel_record.schm 
+				, rel_record.rel
+				, rel_record.uid_column);
+            -- Do something for views
+        END IF;
+		
+	END LOOP;
+END;
+$DO$;

--- a/datamodel/pre_migration.sql
+++ b/datamodel/pre_migration.sql
@@ -1,0 +1,20 @@
+-- Auditing functions moved to app
+DROP FUNCTION IF EXISTS tww_sys.if_modified_func() CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.audit_table(regclass) CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.audit_table(regclass, BOOLEAN, BOOLEAN) CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.audit_table(regclass, BOOLEAN, BOOLEAN, text[]) CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.audit_view(regclass, BOOLEAN, text[], text[]) CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.replay_event(integer) CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.unaudit_table(regclass) CASCADE;
+DROP FUNCTION IF EXISTS tww_sys.unaudit_view(regclass) CASCADE;
+
+-- revert #538
+ALTER TABLE tww_vl.channel_usage_current ADD COLUMN IF NOT EXISTS tww_symbology_inflow_prio bool DEFAULT false;
+UPDATE tww_vl.channel_usage_current
+SET tww_symbology_inflow_prio= true WHERE code =4516;
+
+ALTER TABLE tww_vl.channel_function_hierarchic DROP COLUMN IF NOT EXISTS tww_symbology_inflow_prio;
+
+
+-- Finally: Drop tww_app
+DROP SCHEMA IF EXISTS tww_app CASCADE;


### PR DESCRIPTION
This PR adds a sql script with all the od alterations between 2024_0_5 to 2025_0_1 and runs them before launching PUM. 
Also, it adds a sql script to reload all existing audited triggers