### PR TITLE
Fix_old_sql_roles_links

### DIFF
--- a/docs/en/installation-guide/database-initialization.rst
+++ b/docs/en/installation-guide/database-initialization.rst
@@ -26,8 +26,8 @@ Create  minimal roles and access
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 TWW roles are defined in the
-+ `12_0_roles.sql <https://github.com/teksi/wastewater/tree/main/datamodel/12_0_roles.sql>`_ (per cluster)
-+ `12_1_roles.sql <https://github.com/teksi/wastewater/tree/main/datamodel/12_1_roles.sql>`_ (per database)
++ `12_0_roles.sql <https://github.com/teksi/wastewater/releases/download/2024.0.5/12_0_roles.sql>`_ (per cluster)
++ `12_1_roles.sql <https://github.com/teksi/wastewater/releases/download/2024.0.5/12_1_roles.sql>`_ (per database)
 
 `12_0_roles.sql` has to be run before restoring the demodata database.
 `12_1_roles.sql` has to be run if you initialize your module with with the commandline.

--- a/docs/en/installation-guide/database-initialization.rst
+++ b/docs/en/installation-guide/database-initialization.rst
@@ -32,6 +32,9 @@ TWW roles are defined in the
 `12_0_roles.sql` has to be run before restoring the demodata database.
 `12_1_roles.sql` has to be run if you initialize your module with with the commandline.
 
+
+.. note::
+
 An evolution of the roles management is in progress and will be available soon.
 
 It is highly recommended to use these when using TWW in a production environment.


### PR DESCRIPTION
Fix old sql roles links in the documentation before reworking the whole thing for the new way of installing TEKSI modules.

FIx https://github.com/teksi/wastewater/issues/653