### PR TITLE
set tww_vl.value_list_base.active default to true

### DIFF
--- a/datamodel/changelogs/2025.0.2/02_vl_default_active_true.sql
+++ b/datamodel/changelogs/2025.0.2/02_vl_default_active_true.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tww_vl.value_list_base ALTER COLUMN active SET DEFAULT true;


### PR DESCRIPTION
Needed for adapted vl queries from @sjib, so all not yet existent future vl entries get activated on creation