### PR TITLE
add tww_is_primary to big views

### DIFF
--- a/datamodel/app/view/vw_tww_additional_ws.py
+++ b/datamodel/app/view/vw_tww_additional_ws.py
@@ -61,7 +61,7 @@ def vw_tww_additional_ws(connection: psycopg.Connection, srid: psycopg.sql.Liter
         , ws._output_label
         , wn._usage_current AS _channel_usage_current
         , wn._function_hierarchic AS _channel_function_hierarchic
-
+        , vl_fh.tww_is_primary
         FROM tww_od.wastewater_structure ws
         LEFT JOIN tww_od.cover main_co ON main_co.obj_id = ws.fk_main_cover
         LEFT JOIN tww_od.structure_part main_co_sp ON main_co_sp.obj_id = ws.fk_main_cover
@@ -75,6 +75,7 @@ def vw_tww_additional_ws(connection: psycopg.Connection, srid: psycopg.sql.Liter
         LEFT JOIN tww_od.special_structure ss ON ss.obj_id = ws.obj_id
         LEFT JOIN tww_od.discharge_point dp ON dp.obj_id = ws.obj_id
         LEFT JOIN tww_od.infiltration_installation ii ON ii.obj_id = ws.obj_id
+        LEFT JOIN tww_vl.channel_function_hierarchic vl_fh ON vl_fh.code = wn._function_hierarchic
         WHERE '-1'= ALL(ARRAY[ch.obj_id,ma.obj_id,ss.obj_id,dp.obj_id,ii.obj_id]) IS NULL
         AND '-2'= ALL(ARRAY[ch.obj_id,ma.obj_id,ss.obj_id,dp.obj_id,ii.obj_id]) IS NULL;
     """.format(

--- a/datamodel/app/view/vw_tww_channel.py
+++ b/datamodel/app/view/vw_tww_channel.py
@@ -28,10 +28,12 @@ def vw_tww_channel(connection: psycopg.Connection, extra_definition: dict = None
           {ws_cols}
         , {ch_cols}
         , ST_CurveToLine(ST_LineMerge(ST_Collect(ST_CurveToLine(re.progression3d_geometry)))) as progression3d_geometry
+        , vl_fh.tww_is_primary
       FROM tww_od.channel ch
          LEFT JOIN tww_od.wastewater_structure ws ON ch.obj_id = ws.obj_id
          LEFT JOIN tww_od.wastewater_networkelement ne ON ne.fk_wastewater_structure = ws.obj_id
          LEFT JOIN tww_od.reach re ON ne.obj_id = re.obj_id
+        LEFT JOIN tww_vl.channel_function_hierarchic vl_fh ON vl_fh.code = ch.function_hierarchic
        GROUP BY
          {ch_cols_grp}
         , {ws_cols_grp}

--- a/datamodel/app/view/vw_tww_damage_channel.py
+++ b/datamodel/app/view/vw_tww_damage_channel.py
@@ -28,11 +28,12 @@ def vw_tww_damage_channel(
         {dg_cols},
         {dc_cols},
         ws.identifier AS ws_identifier,
-        ST_LineMerge(ST_Collect(ST_Force2D(re.progression3d_geometry))) AS ch_progression2d_geometry,
+        ch.progression2d_geometry AS ch_progression2d_geometry,
         CASE
           WHEN re_2.obj_id IS NULL THEN 'upstream'::text
           ELSE 'downstream'::text
         END AS direction
+        , ch.tww_is_primary
         FROM tww_od.damage_channel dc
              LEFT JOIN tww_od.damage dg ON dg.obj_id::text = dc.obj_id::text
              LEFT JOIN tww_od.examination ex ON ex.obj_id::text = dg.fk_examination::text
@@ -42,6 +43,7 @@ def vw_tww_damage_channel(
              LEFT JOIN tww_od.reach re ON re.obj_id::text = ne.obj_id::text
              LEFT JOIN tww_od.reach_point rp ON rp.obj_id::text = ex.fk_reach_point::text
              LEFT JOIN tww_od.reach re_2 ON re_2.fk_reach_point_from::text = rp.obj_id::text
+             LEFT JOIN tww_app.vw_tww_channel ch ON ch.obj_id = ws.obj_id
           WHERE ex.recording_type = 3686
           GROUP BY {dg_cols},{dc_cols},ws.identifier, re_2.obj_id
         )

--- a/datamodel/app/view/vw_tww_infiltration_installation.py
+++ b/datamodel/app/view/vw_tww_infiltration_installation.py
@@ -54,6 +54,7 @@ def vw_tww_infiltration_installation(
 
         , wn._usage_current AS _channel_usage_current
         , wn._function_hierarchic AS _channel_function_hierarchic
+        , vl_fh.tww_is_primary
 
 
       FROM tww_od.infiltration_installation ii
@@ -64,6 +65,7 @@ def vw_tww_infiltration_installation(
         LEFT JOIN tww_od.retention_body rb ON rb.fk_infiltration_installation = ws.obj_id
         LEFT JOIN tww_od.wastewater_networkelement ne ON ne.obj_id = ws.fk_main_wastewater_node
         LEFT JOIN tww_od.wastewater_node wn ON wn.obj_id = ws.fk_main_wastewater_node
+        LEFT JOIN tww_vl.channel_function_hierarchic vl_fh ON vl_fh.code = wn._function_hierarchic
         {extra_joins};
     """.format(
         extra_cols="\n    ".join(

--- a/datamodel/app/view/vw_tww_reach.py
+++ b/datamodel/app/view/vw_tww_reach.py
@@ -49,6 +49,7 @@ def vw_tww_reach(connection: psycopg.Connection, extra_definition: dict = None):
         , {ws_cols}
         , {rp_from_cols}
         , {rp_to_cols}
+        , vl_fh.tww_is_primary
       FROM tww_od.reach re
          LEFT JOIN tww_od.wastewater_networkelement ne ON ne.obj_id = re.obj_id
          LEFT JOIN tww_od.reach_point rp_from ON rp_from.obj_id = re.fk_reach_point_from
@@ -56,6 +57,7 @@ def vw_tww_reach(connection: psycopg.Connection, extra_definition: dict = None):
          LEFT JOIN tww_od.wastewater_structure ws ON ne.fk_wastewater_structure = ws.obj_id
          LEFT JOIN tww_od.channel ch ON ch.obj_id = ws.obj_id
          LEFT JOIN tww_od.pipe_profile pp ON re.fk_pipe_profile = pp.obj_id
+        LEFT JOIN tww_vl.channel_function_hierarchic vl_fh ON vl_fh.code = ch.function_hierarchic
          {extra_joins};
     """.format(
         extra_cols="\n    , ".join(

--- a/datamodel/app/view/vw_tww_wastewater_structure.py
+++ b/datamodel/app/view/vw_tww_wastewater_structure.py
@@ -73,6 +73,7 @@ def vw_tww_wastewater_structure(
         , ws._output_label
         , wn._usage_current AS _channel_usage_current
         , wn._function_hierarchic AS _channel_function_hierarchic
+        , vl_fh.tww_is_primary
 
         FROM tww_od.wastewater_structure ws
         LEFT JOIN tww_od.cover main_co ON main_co.obj_id = ws.fk_main_cover
@@ -88,6 +89,7 @@ def vw_tww_wastewater_structure(
         LEFT JOIN tww_od.wwtp_structure wt ON wt.obj_id = ws.obj_id
         LEFT JOIN tww_od.small_treatment_plant sm ON sm.obj_id = ws.obj_id
         LEFT JOIN tww_od.drainless_toilet dt ON dt.obj_id = ws.obj_id
+        LEFT JOIN tww_vl.channel_function_hierarchic vl_fh ON vl_fh.code = wn._function_hierarchic
         WHERE '-1'=ALL(ARRAY[ch.obj_id,dt.obj_id,sm.obj_id,wt.obj_id]) IS NULL
         AND '-2'=ALL(ARRAY[ch.obj_id,dt.obj_id,sm.obj_id,wt.obj_id]) IS NULL;
 

--- a/datamodel/app/view/vw_wastewater_structure.py
+++ b/datamodel/app/view/vw_wastewater_structure.py
@@ -29,10 +29,12 @@ def vw_wastewater_structure(connection: psycopg.Connection, extra_definition: di
         {extra_cols}
         , wn._usage_current AS _channel_usage_current
         , wn._function_hierarchic AS _channel_function_hierarchic
+        , vl_fh.tww_is_primary
 
         FROM tww_od.wastewater_structure ws
         LEFT JOIN tww_od.wastewater_node wn ON wn.obj_id = ws.fk_main_wastewater_node
         LEFT JOIN tww_od.channel ch ON ch.obj_id = ws.obj_id
+        LEFT JOIN tww_vl.channel_function_hierarchic vl_fh ON vl_fh.code = wn._function_hierarchic
         {extra_joins}
         WHERE ch.obj_id IS NULL;
 


### PR DESCRIPTION
For usage in visualisations, it is beneficial to pass the information whether a point/linestring is part of the primary network