### PR TITLE
2025-07-08-clean-up-setup.sh

### DIFF
--- a/datamodel/scripts/setup.sh
+++ b/datamodel/scripts/setup.sh
@@ -41,7 +41,6 @@ psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/changelogs/0001/52_dss1
 psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/changelogs/0001/51_dss15_aquifer_dictionaries.sql -v SRID=$SRID
 psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/changelogs/0001/52_dss15_planning_zone_dictionaries.sql -v SRID=$SRID
 psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/changelogs/0001/90_audit.sql
-psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_0_roles.sql
-psql "service=${PGSERVICE}" -v ON_ERROR_STOP=1 -f ${DIR}/12_1_roles.sql
+
 
 ${DIR}/app/create_app.py --pg_service ${PGSERVICE} --srid ${SRID}


### PR DESCRIPTION
From what I understand these calls are not needed anymore in the setup.sh

- [x] remove call of 12_0 and 12_1_roles.sql in setup.sh

@3nids @ponceta 

Is there already a documentation how the roles managemet will work with TMMT and the new PUM?