### PR TITLE
bump QGIS Version for plugin tests

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-      qgis_version: [3.40-jammy, latest]
+        qgis_version: [3.40-jammy, latest]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
       COMPOSE_PROFILES: qgis

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -29,22 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qgis_version: [3.40-jammy, latest]
-        test_name: [QGIS, DSS , cmd]
-        include:
-          - test_name: QGIS
-            test_command: "/usr/src/plugin/.docker/run-docker-tests.sh --deselect teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export"
-          - test_name: DSS
-            test_command: "/usr/src/plugin/.docker/run-docker-tests.sh teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export"
-          - test_name: cmd
-            test_command: |
-              sh -c '
-              set -e;
-              xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-organisation-arbon-only.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432 &&
-              xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-SIA405-ABWASSER.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432 &&
-              xvfb-run /usr/src/plugin/tww_cmd.py interlis_export --xtf_file "output.xtf" --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432
-              '
-
+      qgis_version: [3.40-jammy, latest]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
       COMPOSE_PROFILES: qgis
@@ -67,7 +52,7 @@ jobs:
       - name: Docker build
         run: docker compose --profile qgis up -d --build
 
-      - name: Create Database
+      - name: Clear Database
         run: |
           until docker compose exec db pg_isready -U postgres; do
             echo "Waiting for PostgreSQL to be ready..."
@@ -76,10 +61,33 @@ jobs:
           # create the database
           docker compose exec db sh -c 'createdb tww'
           docker compose exec db pum -s pg_tww -d datamodel install -p SRID 2056 --roles --grant
-          docker compose exec db sh -c 'psql -U postgres -c "GRANT tww_user TO postgres;"'
 
-      - name: Test on ${{matrix.test_name}}
-        run: docker compose run qgis ${{ matrix.test_command }}
+      - name: Test on QGIS
+        run: docker compose run qgis /usr/src/plugin/.docker/run-docker-tests.sh --deselect teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export
+
+      - name: Clear Database
+        run: |
+          docker compose exec db sh -c 'dropdb tww'
+          docker compose exec db sh -c 'createdb tww'
+          docker compose exec db pum -s pg_tww -d datamodel install -p SRID 2056
+
+      - name: Test on QGIS DSS dataset
+        run: docker compose run qgis /usr/src/plugin/.docker/run-docker-tests.sh teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export
+
+      - name: Clear Database
+        run: |
+          docker compose exec db sh -c 'dropdb tww'
+          docker compose exec db sh -c 'createdb tww'
+          docker compose exec db pum -s pg_tww -d datamodel install -p SRID 2056
+
+      - name: Test command line import orgs
+        run: docker compose run qgis sh -c 'xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-organisation-arbon-only.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432'
+
+      - name: Test command line import minimal sia405
+        run: docker compose run qgis sh -c 'xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-SIA405-ABWASSER.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432'
+
+      - name: Test command line minimal export
+        run: docker compose run qgis sh -c 'xvfb-run /usr/src/plugin/tww_cmd.py interlis_export --xtf_file "output.xtf" --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432'
 
       - name: docker logs
         run: docker compose logs db

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qgis_version: [3.34-jammy, latest]
+        qgis_version: [3.40-jammy, latest]
         test_name: [QGIS, DSS , cmd]
         include:
           - test_name: QGIS

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -30,6 +30,21 @@ jobs:
       fail-fast: false
       matrix:
         qgis_version: [3.34-jammy, latest]
+        test_name: [QGIS, DSS , cmd]
+        include:
+          - test_name: QGIS
+            test_command: "/usr/src/plugin/.docker/run-docker-tests.sh --deselect teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export"
+          - test_name: DSS
+            test_command: "/usr/src/plugin/.docker/run-docker-tests.sh teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export"
+          - test_name: cmd
+            test_command: |
+              sh -c '
+              set -e;
+              xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-organisation-arbon-only.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432 &&
+              xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-SIA405-ABWASSER.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432 &&
+              xvfb-run /usr/src/plugin/tww_cmd.py interlis_export --xtf_file "output.xtf" --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432
+              '
+
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
       COMPOSE_PROFILES: qgis
@@ -52,7 +67,7 @@ jobs:
       - name: Docker build
         run: docker compose --profile qgis up -d --build
 
-      - name: Clear Database
+      - name: Create Database
         run: |
           until docker compose exec db pg_isready -U postgres; do
             echo "Waiting for PostgreSQL to be ready..."
@@ -61,33 +76,10 @@ jobs:
           # create the database
           docker compose exec db sh -c 'createdb tww'
           docker compose exec db pum -s pg_tww -d datamodel install -p SRID 2056 --roles --grant
+          docker compose exec db sh -c 'psql -U postgres -c "GRANT tww_user TO postgres;"'
 
-      - name: Test on QGIS
-        run: docker compose run qgis /usr/src/plugin/.docker/run-docker-tests.sh --deselect teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export
-
-      - name: Clear Database
-        run: |
-          docker compose exec db sh -c 'dropdb tww'
-          docker compose exec db sh -c 'createdb tww'
-          docker compose exec db pum -s pg_tww -d datamodel install -p SRID 2056
-
-      - name: Test on QGIS DSS dataset
-        run: docker compose run qgis /usr/src/plugin/.docker/run-docker-tests.sh teksi_wastewater/tests/test_interlis.py::TestInterlis::test_dss_dataset_import_export
-
-      - name: Clear Database
-        run: |
-          docker compose exec db sh -c 'dropdb tww'
-          docker compose exec db sh -c 'createdb tww'
-          docker compose exec db pum -s pg_tww -d datamodel install -p SRID 2056
-
-      - name: Test command line import orgs
-        run: docker compose run qgis sh -c 'xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-organisation-arbon-only.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432'
-
-      - name: Test command line import minimal sia405
-        run: docker compose run qgis sh -c 'xvfb-run /usr/src/plugin/tww_cmd.py interlis_import --xtf_file /usr/src/plugin/teksi_wastewater/tests/data/minimal-dataset-SIA405-ABWASSER.xtf --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432'
-
-      - name: Test command line minimal export
-        run: docker compose run qgis sh -c 'xvfb-run /usr/src/plugin/tww_cmd.py interlis_export --xtf_file "output.xtf" --pghost db --pgdatabase tww --pguser postgres --pgpass postgres --pgport 5432'
+      - name: Test on ${{matrix.test_name}}
+        run: docker compose run qgis ${{ matrix.test_command }}
 
       - name: docker logs
         run: docker compose logs db


### PR DESCRIPTION
This PR splits the plugin tests into modular components and bumps the tests from 3.34-jammy to 3.40-jammy 