### PR TITLE
Divide actions

### DIFF
--- a/.github/workflows/datamodel-create-documentation.yml
+++ b/.github/workflows/datamodel-create-documentation.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Schemaspy
         if: ${{ matrix.extension == '' }}
-        run:  docker compose run schemaspy
+        run:  docker compose up schemaspy
 
       - name: Docker logs
         if: failure()

--- a/.github/workflows/datamodel-create-documentation.yml
+++ b/.github/workflows/datamodel-create-documentation.yml
@@ -1,4 +1,4 @@
-name: 📦 Datamodel | Create dumps
+name: 📦 Datamodel | Create documentation
 
 concurrency:
   group: dumps-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,22 +13,23 @@ on:
       - main
     paths:
       - datamodel/**
-      - '.github/workflows/datamodel-create-dumps.yml'
+      - '.github/workflows/datamodel-create-documentation.yml'
   workflow_dispatch:
   workflow_call: # Allows this workflow to be called by other workflows
       inputs:
         release_tag:
           required: false
-          description: 'Release tag to upload dumps as GitHub Release asset'
+          description: 'Release tag to upload datamodel documentation as GitHub Release asset'
           default: ''
           type: string
 
 
 jobs:
   datamodel-dumps:
-    name: Create dumps of datamodel
+    name: Create datamodel documentation
     runs-on: ubuntu-24.04
     env:
+      COMPOSE_PROFILES: schemaspy
       COMPOSE_PROJECT_NAME: wastewater-${{ matrix.extension }}
 
     strategy:
@@ -51,31 +52,29 @@ jobs:
           docker compose exec db createdb -U postgres tww
           docker compose exec db pum -vvv -s pg_tww -d datamodel install -p SRID 2056 -p modification_agxx ${{ matrix.extension != '' && 'true' || 'false' }} --roles --grant
 
-      - name: Create dumps
-        run: docker compose exec db /src/datamodel/scripts/create-dumps.py --extension_name=${{ matrix.extension }}
+      - name: Schemaspy
+        if: ${{ matrix.extension == '' }}
+        run:  docker compose run schemaspy
 
       - name: Docker logs
         if: failure()
         run: docker compose logs db
 
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.extension == '' }}
         with:
-          name: datamodel-dumps${{ matrix.extension != '' && format('_{0}', matrix.extension) || matrix.extension }}
-          path: datamodel/artifacts/
+          name: datamodel-schemaspy
+          path: datamodel/schemaspy/
           if-no-files-found: error
 
-      - name: Zip datamodel dumps
-        run: |
-           zip -r datamodel-dumps${{ matrix.extension != '' && format('_{0}', matrix.extension) || matrix.extension }}.zip datamodel/artifacts
+      - name: Zip schemaspy output
+        run: zip -r datamodel-schemaspy${{ matrix.extension != '' && format('_{0}', matrix.extension) || matrix.extension }}.zip datamodel/schemaspy
 
-      - name: Upload datamodel dumps as GitHub Release asset
+      - name: Upload datamodel documentation as GitHub Release asset
         if: ${{ inputs.release_tag != '' }}
         run: |
           if [ -z "${{ matrix.extension }}" ]; then
-            gh release upload "${{ inputs.release_tag }}" datamodel-dumps.zip#oqtopus.datamodel --repo "$GITHUB_REPOSITORY"
-          else
-            gh release upload "${{ inputs.release_tag }}" datamodel-dumps_${{ matrix.extension }}.zip#oqtopus.datamodel --repo "$GITHUB_REPOSITORY"
-          fi
+            gh release upload "${{ inputs.release_tag }}" datamodel-schemaspy.zip --repo "$GITHUB_REPOSITORY"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a draft and it can surely be better written but I think if we can run separate jobs for datamodel dumps creations and schemaspy, it could be for the best in terms of stability/readability.