### PR TITLE
remove ag-xx dump from artifacts

### DIFF
--- a/.github/workflows/datamodel-create-dumps.yml
+++ b/.github/workflows/datamodel-create-dumps.yml
@@ -30,11 +30,9 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       COMPOSE_PROFILES: schemaspy
-      COMPOSE_PROJECT_NAME: wastewater-${{ matrix.extension }}
+      COMPOSE_PROJECT_NAME: wastewater
 
     strategy:
-      matrix:
-        extension: ["", "agxx"]
       fail-fast: false
 
     steps:
@@ -50,13 +48,12 @@ jobs:
             sleep 2
           done
           docker compose exec db createdb -U postgres tww
-          docker compose exec db pum -vvv -s pg_tww -d datamodel install -p SRID 2056 -p modification_agxx ${{ matrix.extension != '' && 'true' || 'false' }} --roles --grant
+          docker compose exec db pum -vvv -s pg_tww -d datamodel install -p SRID 2056 --roles --grant
 
       - name: Create dumps
-        run: docker compose exec db /src/datamodel/scripts/create-dumps.py --extension_name=${{ matrix.extension }}
+        run: docker compose exec db /src/datamodel/scripts/create-dumps.py
 
       - name: Schemaspy
-        if: ${{ matrix.extension == '' }}
         run:  docker compose up schemaspy
 
       - name: Docker logs
@@ -65,12 +62,11 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: datamodel-dumps${{ matrix.extension != '' && format('_{0}', matrix.extension) || matrix.extension }}
+          name: datamodel-dumps
           path: datamodel/artifacts/
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.extension == '' }}
         with:
           name: datamodel-schemaspy
           path: datamodel/schemaspy/
@@ -78,20 +74,16 @@ jobs:
 
       - name: Zip datamodel dumps
         run: |
-           zip -r datamodel-dumps${{ matrix.extension != '' && format('_{0}', matrix.extension) || matrix.extension }}.zip datamodel/artifacts
+           zip -r datamodel-dumps.zip datamodel/artifacts
 
       - name: Zip schemaspy output
-        run: zip -r datamodel-schemaspy${{ matrix.extension != '' && format('_{0}', matrix.extension) || matrix.extension }}.zip datamodel/schemaspy
+        run: zip -r datamodel-schemaspy.zip datamodel/schemaspy
 
       - name: Upload datamodel dumps as GitHub Release asset
         if: ${{ inputs.release_tag != '' }}
         run: |
-          if [ -z "${{ matrix.extension }}" ]; then
-            gh release upload "${{ inputs.release_tag }}" datamodel-dumps.zip --repo "$GITHUB_REPOSITORY"
-            gh release upload "${{ inputs.release_tag }}" datamodel-schemaspy.zip --repo "$GITHUB_REPOSITORY"
-          else
-            gh release upload "${{ inputs.release_tag }}" datamodel-dumps_${{ matrix.extension }}.zip --repo "$GITHUB_REPOSITORY"
-          fi
+          gh release upload "${{ inputs.release_tag }}" datamodel-dumps.zip --repo "$GITHUB_REPOSITORY"
+          gh release upload "${{ inputs.release_tag }}" datamodel-schemaspy.zip --repo "$GITHUB_REPOSITORY"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With the roll-out of TMMT, dumping additional artifacts becomes obsolete