### PR TITLE
Fix sequence limit

### DIFF
--- a/datamodel/app/sql_functions/oid_functions.sql
+++ b/datamodel/app/sql_functions/oid_functions.sql
@@ -62,7 +62,11 @@ BEGIN
 				EXECUTE FORMAT('SELECT SETVAL(''tww_od.seq_%1$I_oid'',(SELECT max(seqs) FROM(
 		SELECT tww_app.base36_to_int(RIGHT(obj_id, 6)) as seqs
 		FROM tww_od.%1$I
-		WHERE regexp_match(obj_id, ''%2$s[0-9a-z]{{6}}$'') IS NOT NULL
+		WHERE regexp_match(obj_id, ''%2$s(?=[0-9a-z]*[a-z])[0-9a-z]{{6}}$'') IS NOT NULL
+		UNION
+		SELECT RIGHT(obj_id, 6)::int as seqs
+		FROM tww_od.%1$I
+		WHERE regexp_match(obj_id, ''%2$s[0-9]{{6}}$'') IS NOT NULL
 		UNION
 		SELECT last_value as seqs FROM tww_od.seq_%1$I_oid)foo));',tbl_name,rgx);
 	   END LOOP;

--- a/datamodel/changelogs/2025.0.2/99_set_sequences_base36.sql
+++ b/datamodel/changelogs/2025.0.2/99_set_sequences_base36.sql
@@ -1,0 +1,16 @@
+DO
+$BODY$
+DECLARE
+tbl_name text;
+BEGIN
+	BEGIN
+	   FOR tbl_name IN (
+			SELECT dot.tablename
+			FROM information_schema.sequences seq
+			LEFT JOIN tww_sys.dictionary_od_table dot ON seq.sequence_name = 'seq_'||dot.tablename||'_oid'
+			WHERE seq.sequence_schema = 'tww_od' AND dot.tablename IS NOT NULL) LOOP
+				EXECUTE FORMAT('ALTER SEQUENCE tww_od.seq_%1$I_oid MAXVALUE 2176782335;',tbl_name,rgx);
+	   END LOOP;
+	END;
+END;
+$BODY$;


### PR DESCRIPTION
in https://github.com/teksi/wastewater/issues/210#issuecomment-3381143947 a problem was found that the conversion of oid prefixes to base36 caused problems in setting the value of sequences. This PR

1. raises the maximum for new sequences
2. adds a filter for purely numeric oid postfixes so they are not filtered as base36