### PR TITLE
Fix app creation statements order for oQtopus

### DIFF
--- a/datamodel/app/create_app.py
+++ b/datamodel/app/create_app.py
@@ -306,7 +306,6 @@ Running modification {modification.get('id')}
         # run post_all
         self.run_sql_files_in_folder(self.cwd / "post_all")
 
-
     @staticmethod
     def load_yaml(file: Path) -> dict[str]:
         """Safely loads a YAML file and ensures it returns a dictionary."""


### PR DESCRIPTION
Investigating to fix https://github.com/teksi/wastewater/issues/697

Apparently, statement order has a result on what is pushed in the database from QGIS and oqtopus and it may be related to the fact that some statements are not committed to the database.

See https://github.com/teksi/wastewater/pull/811 for investigating invalid commit mechanics.

