### PR TITLE
allow to run PR docs faster

### DIFF
--- a/.github/workflows/docs-builder.yml
+++ b/.github/workflows/docs-builder.yml
@@ -38,8 +38,13 @@ jobs:
 
       - name: install requirements
         working-directory: docs
+        run: pip install -r requirements.txt
+
+      - name: install tx requirements
+        if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR-fast-doc')) }}
+        working-directory: docs
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements-tx.txt
           sudo apt-get install -y gettext
           curl -OL https://github.com/transifex/cli/releases/download/v1.6.10/tx-linux-amd64.tar.gz
           tar -xvzf tx-linux-amd64.tar.gz
@@ -49,7 +54,7 @@ jobs:
         run: mkdir -p docs/_static/datamodel
 
       - name: tx pull
-        if: ${{ github.event.pull_request.head.repo.full_name == 'teksi/wastewater' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+        if: ${{ ( github.event.pull_request.head.repo.full_name == 'teksi/wastewater' || github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule') && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'PR-fast-doc')) }}
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         working-directory: docs

--- a/docs/requirements-tx.txt
+++ b/docs/requirements-tx.txt
@@ -1,0 +1,1 @@
+transifex-client

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 sphinx
 sphinx-rtd-theme
 Pygments>=2.0.1
-transifex-client


### PR DESCRIPTION
Adding the Label PR-fast-doc to a Pull request
will trigger a fast documentation with no build of the datamodel structure documentation and no translation

Edit by @ponceta 18.11.2025