### PR TITLE
Use DatabaseUtils in refresh topology

### DIFF
--- a/plugin/teksi_wastewater/tools/twwnetwork.py
+++ b/plugin/teksi_wastewater/tools/twwnetwork.py
@@ -37,8 +37,8 @@ import networkx as nx
 from qgis.core import NULL, Qgis, QgsGeometry, QgsMessageLog, QgsPointXY
 from qgis.PyQt.QtCore import QObject, Qt, pyqtSignal
 
-from ..utils.qt_utils import OverrideCursor
 from ..utils.database_utils import DatabaseUtils
+from ..utils.qt_utils import OverrideCursor
 
 
 class TwwGraphManager(QObject):
@@ -164,11 +164,10 @@ class TwwGraphManager(QObject):
             with OverrideCursor(Qt.WaitCursor):
                 DatabaseUtils.refresh_matviews()
             self.message_emitted.emit(
-                    self.tr("Success"),
-                    self.tr("Materialized Views successfully updated"),
-                    Qgis.Success,
-                )
-
+                self.tr("Success"),
+                self.tr("Materialized Views successfully updated"),
+                Qgis.Success,
+            )
 
         except Exception as exception:
             self.message_emitted.emit(
@@ -182,12 +181,10 @@ class TwwGraphManager(QObject):
             self.graph.clear()
             self.createGraph()
             self.message_emitted.emit(
-                    self.tr("Success"),
-                    self.tr("Network successfully updated"),
-                    Qgis.Success,
-                )
-
-
+                self.tr("Success"),
+                self.tr("Network successfully updated"),
+                Qgis.Success,
+            )
 
         except Exception as exception:
             self.message_emitted.emit(

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -238,4 +238,3 @@ class DatabaseUtils:
     def refresh_matviews():
         logger.info("Refreshing materialized views")
         DatabaseUtils.execute("SELECT tww_app.network_refresh_network_simple();")
-


### PR DESCRIPTION
This PR uses the DatabaseUtils on the "Refresh topology" button instead of relying on the transaction of vw_network_node