### PR TITLE
reduce validity checks to warning

### DIFF
--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -366,9 +366,9 @@ class TeksiWastewaterPlugin:
 
         for message in messages:
             self.iface.messageBar().pushMessage(
-                "Error",
+                "Warning",
                 message,
-                level=Qgis.Critical,
+                level=Qgis.Warning,
             )
 
     def tww_validity_check_action(self):


### PR DESCRIPTION
Instead of pushing Qgis.critical, the tww_validity_check_startup now raise  a warning