### PR TITLE
improve identifier synchronization for wastewater structures

### DIFF
--- a/datamodel/test/test_views.py
+++ b/datamodel/test/test_views.py
@@ -102,6 +102,118 @@ class TestViews(unittest.TestCase, DbTestBase):
 
         assert row["backflow_level_current"] == decimal.Decimal("100.000")
 
+    def test_vw_tww_wastewater_structure_identifier_synchronization(self):
+        base_row = {
+            "ws_type": "manhole",
+            "situation3d_geometry": self.execute(
+                "ST_SetSRID(ST_GeomFromText('POINT(2600000 1200000)'), 2056)"
+            ),
+            "co_material": 233,
+        }
+
+        # -------
+        # test that wn_identifier is correctly on insert and no cover is created (if no cover fields are set)
+        row = copy.deepcopy(base_row)
+        row["identifier"] = "ws_000"
+        row["co_material"] = None
+
+        expected_row = copy.deepcopy(row)
+        expected_row["wn_identifier"] = "ws_000"
+        expected_row["co_identifier"] = None
+
+        obj_id = self.insert_check(
+            "vw_tww_wastewater_structure", row=row, expected_row=expected_row
+        )
+
+        # -------
+        # test that wn_identifier and co_identifier are set correctly on insert when cover fields are set
+        row = copy.deepcopy(base_row)
+        row["identifier"] = "ws_001"
+
+        expected_row = copy.deepcopy(row)
+        expected_row["wn_identifier"] = "ws_001"
+        expected_row["co_identifier"] = "ws_001"
+
+        obj_id = self.insert_check(
+            "vw_tww_wastewater_structure", row=row, expected_row=expected_row
+        )
+
+        # -------
+        # test that wn_identifier and co_identifier are synchronized correctly on update
+        row = copy.deepcopy(expected_row)
+        row["identifier"] = "ws_002"
+
+        expected_row = copy.deepcopy(row)
+        expected_row["wn_identifier"] = "ws_002"
+        expected_row["co_identifier"] = "ws_002"
+
+        self.update_check(
+            "vw_tww_wastewater_structure",
+            row={"identifier": "ws_002"},
+            obj_id=obj_id,
+            expected_row=expected_row,
+        )
+
+        # -------
+        # test that differentiating identifiers on update works
+        row = copy.deepcopy(expected_row)
+        row["identifier"] = "ws_003"
+        row["co_identifier"] = "cover_003"
+        row["wn_identifier"] = "wn_003"
+        expected_row = copy.deepcopy(row)
+        expected_row["wn_identifier"] = "ws_003"
+        expected_row["co_identifier"] = "cover_003"
+        expected_row["wn_identifier"] = "wn_003"
+        self.update_check(
+            "vw_tww_wastewater_structure",
+            row=row,
+            obj_id=obj_id,
+            expected_row=expected_row,
+        )
+
+        # -------
+        # test former existing cover prevents new cover creation on insert
+        row = copy.deepcopy(base_row)
+        row["identifier"] = "ws_004"
+        row["co_identifier"] = "cover_003"  # cover_003 already exists
+        expected_row = copy.deepcopy(row)
+        expected_row["co_identifier"] = (
+            None  # co_identifier is set to null because cover creation is prevented
+        )
+        expected_row["co_material"] = None
+        obj_id = self.insert_check(
+            "vw_tww_wastewater_structure",
+            row=row,
+            expected_row=expected_row,
+        )
+
+        # -------
+        # test former existing cover prevents new cover creation on update
+        row = copy.deepcopy(base_row)
+        row["identifier"] = "ws_005"
+        row["co_material"] = None
+        expected_row = copy.deepcopy(row)
+        expected_row["co_identifier"] = None
+        obj_id = self.insert_check(
+            "vw_tww_wastewater_structure",
+            row=row,
+            expected_row=expected_row,
+        )
+        row = copy.deepcopy(base_row)
+        row["identifier"] = "ws_005_updated"
+        row["co_identifier"] = "cover_003"  # cover_003 already exists
+        expected_row = copy.deepcopy(row)
+        expected_row["co_identifier"] = (
+            None  # co_identifier is null because cover creation is prevented
+        )
+        expected_row["co_material"] = None
+        self.update_check(
+            "vw_tww_wastewater_structure",
+            row=row,
+            obj_id=obj_id,
+            expected_row=expected_row,
+        )
+
     def test_vw_tww_additional_ws(self):
         row = {
             "identifier": "201_created",

--- a/datamodel/test/utils.py
+++ b/datamodel/test/utils.py
@@ -94,10 +94,12 @@ class DbTestBase:
 
         return obj_id
 
-    def update_check(self, table, row, obj_id, schema="tww_app"):
+    def update_check(self, table, row, obj_id, expected_row=None, schema="tww_app"):
         self.update(table, row, obj_id, schema=schema)
         result = self.select(table, obj_id, schema=schema)
-        self.check_result(row, result, table, "update", schema)
+        if not expected_row:
+            expected_row = row
+        self.check_result(expected_row, result, table, "update", schema)
 
     def check_result(self, expected, result, table, test_name, schema="tww_app"):
         # TODO: don't convert to unicode, type inference for smallint is


### PR DESCRIPTION
Fixes #815

This adapts the synchronization of identifiers, following the idea that identifiers are null.

For WS / CO / WN nodes, they are kept in sync:
- insert: if only main is provided, all 3 get the same value
- update: if they were the same and the main changes => all changes


I'll try to summarize the implemented behavior for covers:

* INSERT
  * if cover with same identifier doesn't exist, then it's created 
  * if cover with same identifier already exist with identifier, no creation + notification
 
* UPDATE
  * if linked cover exists, it's updated (but it's not yet checked if the identifier is updated to an already existing one)
  * if linked cover doesn't exists
    * if cover with same identifier doesn't exist, then it's created 
    * if cover with same identifier already exist with identifier, no creation + notification

(plus in general, if there is no cover data, no cover is created)

open question:
* do the nodes require more attention?
* ~~I am a bit skeptical about the way things are implemented:~~
  *  ~~either we prohibit identifier duplication (by adding a constraint instead of an index)~~
  *  ~~either we allow duplicates, then the trigger should not discard the creation (or at least have an option for this)~~
  *  ~~or I have badly understood the uniqueness, which would be per wastewater_structure (ant not globally) which means this needs a small adaption in the checks~~