### PR TITLE
Add a view that can label inlets/outlets

### DIFF
--- a/datamodel/app/view/varia/vw_labeling_inlets_outlets.sql
+++ b/datamodel/app/view/varia/vw_labeling_inlets_outlets.sql
@@ -1,0 +1,85 @@
+DROP MATERIALIZED VIEW IF EXISTS tww_app.vw_labeling_inlets_outlets CASCADE;
+CREATE MATERIALIZED VIEW tww_app.vw_labeling_inlets_outlets
+AS
+ WITH inlet AS (
+    SELECT ne.obj_id AS obj_id_ne,
+    ne.identifier AS network_element_identifier,
+        CASE
+            WHEN st_length(re.progression3d_geometry) > 1::double precision THEN st_lineinterpolatepoint(st_geomfromtext(st_astext(st_curvetoline(re.progression3d_geometry)), 2056), 1::double precision - 1::double precision / st_length(re.progression3d_geometry))
+            WHEN st_length(re.progression3d_geometry) < 1::double precision THEN st_lineinterpolatepoint(st_geomfromtext(st_astext(st_curvetoline(re.progression3d_geometry)), 2056), 0.7::double precision)
+            ELSE st_lineinterpolatepoint(st_geomfromtext(st_astext(st_curvetoline(re.progression3d_geometry)), 2056), 0.000001::double precision)
+        END AS geom,
+    rp.level,
+    rp.obj_id AS obj_id_rp,
+    usg_curr.value_de AS usage_current,
+    stat.value_de AS astatus,
+    re.obj_id AS fk_reach,
+    wn.obj_id AS fk_wastewater_node,
+    'inlet'::text AS type
+    FROM tww_od.wastewater_networkelement ne
+        LEFT JOIN tww_od.reach_point rp ON rp.fk_wastewater_networkelement::text = ne.obj_id::text
+        LEFT JOIN tww_od.reach re ON re.fk_reach_point_to::text = rp.obj_id::text
+        LEFT JOIN tww_od.wastewater_structure ws ON ne.fk_wastewater_structure::text = ws.obj_id::text
+        LEFT JOIN tww_vl.wastewater_structure_status stat ON ws.status = stat.code
+        LEFT JOIN tww_od.wastewater_node wn ON wn.obj_id::text = ws.fk_main_wastewater_node::text
+        LEFT JOIN tww_vl.channel_usage_current usg_curr ON wn._usage_current = usg_curr.code
+    WHERE re.progression3d_geometry IS NOT NULL AND wn.obj_id IS NOT NULL
+    ORDER BY rp.level DESC
+), 
+outlet AS (
+    SELECT ne.obj_id AS obj_id_ne,
+    ne.identifier AS network_element_identifier,
+        CASE
+            WHEN st_length(re.progression3d_geometry) > 1::double precision THEN st_lineinterpolatepoint(st_geomfromtext(st_astext(st_curvetoline(re.progression3d_geometry)), 2056), 1::double precision / st_length(re.progression3d_geometry))
+            WHEN st_length(re.progression3d_geometry) < 1::double precision THEN st_lineinterpolatepoint(st_geomfromtext(st_astext(st_curvetoline(re.progression3d_geometry)), 2056), 0.7::double precision)
+            ELSE st_lineinterpolatepoint(st_geomfromtext(st_astext(st_curvetoline(re.progression3d_geometry)), 2056), 0.000001::double precision)
+        END AS geom,
+    rp.level,
+    rp.obj_id AS obj_id_rp,
+    usg_curr.value_de AS usage_current,
+    stat.value_de AS astatus,
+    re.obj_id AS fk_reach,
+    wn.obj_id AS fk_wastewater_node,
+    'outlet'::text AS type
+    FROM tww_od.wastewater_networkelement ne
+        LEFT JOIN tww_od.reach_point rp ON rp.fk_wastewater_networkelement::text = ne.obj_id::text
+        LEFT JOIN tww_od.reach re ON re.fk_reach_point_from::text = rp.obj_id::text
+        LEFT JOIN tww_od.wastewater_structure ws ON ne.fk_wastewater_structure::text = ws.obj_id::text
+        LEFT JOIN tww_vl.wastewater_structure_status stat ON ws.status = stat.code
+        LEFT JOIN tww_od.wastewater_node wn ON wn.obj_id::text = ws.fk_main_wastewater_node::text
+        LEFT JOIN tww_vl.channel_usage_current usg_curr ON wn._usage_current = usg_curr.code
+    WHERE re.progression3d_geometry IS NOT NULL AND wn.obj_id IS NOT NULL
+    ORDER BY rp.level DESC
+)
+ SELECT uuid_generate_v4() AS _uuid,
+    i.obj_id_ne,
+    i.network_element_identifier,
+    st_force2d(i.geom) AS geom,
+    COALESCE(i.level::text, '?'::text) AS level,
+    i.obj_id_rp,
+    i.usage_current,
+    i.astatus,
+    i.fk_reach,
+    i.fk_wastewater_node,
+    i.type,
+    'E'::text || row_number() OVER (PARTITION BY i.obj_id_ne ORDER BY i.level DESC)::text AS _label
+   FROM inlet i
+UNION ALL
+ SELECT uuid_generate_v4() AS _uuid,
+    o.obj_id_ne,
+    o.network_element_identifier,
+    st_force2d(o.geom) AS geom,
+    COALESCE(o.level::text, '?'::text) AS level,
+    o.obj_id_rp,
+    o.usage_current,
+    o.astatus,
+    o.fk_reach,
+    o.fk_wastewater_node,
+    o.type,
+    'A'::text || row_number() OVER (PARTITION BY o.obj_id_ne ORDER BY o.level DESC)::text AS _label
+   FROM outlet o;
+
+
+CREATE INDEX labeling_inlets_outlets_geom_idx
+  ON tww_app.vw_labeling_inlets_outlets
+  USING GIST (geom);

--- a/datamodel/app/view/varia/vw_labeling_inlets_outlets.sql
+++ b/datamodel/app/view/varia/vw_labeling_inlets_outlets.sql
@@ -25,7 +25,7 @@ AS
         LEFT JOIN tww_vl.channel_usage_current usg_curr ON wn._usage_current = usg_curr.code
     WHERE re.progression3d_geometry IS NOT NULL AND wn.obj_id IS NOT NULL
     ORDER BY rp.level DESC
-), 
+),
 outlet AS (
     SELECT ne.obj_id AS obj_id_ne,
     ne.identifier AS network_element_identifier,


### PR DESCRIPTION
This was developed for Einwohnergemeinde Zermatt, in order to publish their wastewater cadastre. Since we thought this might be helpful we figured we would share it here so other people can benefit from it.

It is a matview that can generate (mostly 😅) sensibly positioned labels for inlets/outlets of wastewater structures:

<img width="1113" height="831" alt="image" src="https://github.com/user-attachments/assets/237138b1-7956-4000-85e9-9dbcdc08ac3b" />

In the [WebGIS](https://webgis.zermatt.ch/?t=werkplan_abwasser&l=einlauf_auslauf%2Cdeckel%21%2Cabwasserbauwerk%2Cabwasserleitung%2Cinliner%21%2Ceigentum_abwasserbauwerk~%2Ceigentum_abwasserleitung~%2Cabwasserbauwerksflaeche%2Cabwasserleitung_horizontale_ausdehnung%5B30%5D%2Ckaverne_ara%2Centwaesserungsgebiete%21%2Cfokus_gemeindegebiet%5B50%5D%21%2CBelastete%20Standorte%21%2Cgefaehrdungskarte_oberflaechenabfluss%5B40%5D%21%2Chochwassergefahrenkarte%5B48%5D%21%2Cintensitaet_hochwasser_hq30%5B40%5D%21%2Cintensitaet_hochwasser_hq100%5B40%5D%21%2Cintensitaet_hochwasser_hq300%5B40%5D%21%2Cgwsz_s1~%2Cgwsz_s2~%2Cgwsz_s3~%2Cgwsz_au%5B70%5D~%2Cgwsz_ao%5B80%5D~%2Cofoto25%21&bl=bg_orthofoto_2025&c=2624413%2C1097485&s=25) you can see that for very short reaches the positioning is not perfect, but it usually does the trick.

---

What could be improved

- As Zermatt do not need mulitple languages the labels are generated as `E1` and `A2` and so on, this could probably become a setting of some sort in `tww_sys` or `tww_cfg` to allow for multiple languages.
- I of course did not know where to put the file in the project structure and where it would need to be registered for it to be considered in the "database construction" (setup / or version update) step - you will know where to put it.
- It could maybe even be integrated in the `SQL` Button within the QGIS Plugin, so the View is refreshed when that button is pressed
- It can take quite a while to compute. If anyone knows some tricks to improve this, that might be good