### PR TITLE
Add outflow to test_crossing_circular_reaches test

### DIFF
--- a/datamodel/test/test_label.py
+++ b/datamodel/test/test_label.py
@@ -138,7 +138,7 @@ class TestViews(unittest.TestCase, DbTestBase):
                 {"mh_id": "S", "rp_to_level": 1012, "mid_point": [2600000.5, 1200000.5]},
             ],
             "output": [
-                {"mh_id": "W", "rp_from_level": 1010, "mid_point": [2599999.5, 51200000]},
+                {"mh_id": "W", "rp_from_level": 1010, "mid_point": [2599999.5, 1200000]},
             ],
         }
         self.insert_reaches(reaches, manholes)

--- a/datamodel/test/test_label.py
+++ b/datamodel/test/test_label.py
@@ -138,7 +138,7 @@ class TestViews(unittest.TestCase, DbTestBase):
                 {"mh_id": "S", "rp_to_level": 1012, "mid_point": [2600000.5, 1200000.5]},
             ],
             "output": [
-                {"mh_id": "W", "rp_from_level": 1010,"mid_point": [2599999.5,51200000]},
+                {"mh_id": "W", "rp_from_level": 1010, "mid_point": [2599999.5, 51200000]},
             ],
         }
         self.insert_reaches(reaches, manholes)

--- a/datamodel/test/test_label.py
+++ b/datamodel/test/test_label.py
@@ -129,18 +129,22 @@ class TestViews(unittest.TestCase, DbTestBase):
             "main": {"obj_id": None, "wn_obj_id": None, "coords": [2600000, 1200000]},
             "N": {"obj_id": None, "wn_obj_id": None, "coords": [2600000, 1200001]},
             "S": {"obj_id": None, "wn_obj_id": None, "coords": [2600000, 1199999]},
+            "W": {"obj_id": None, "wn_obj_id": None, "coords": [2599999, 1200000]},
         }
         self.insert_manholes(manholes)
         reaches = {
             "input": [
                 {"mh_id": "N", "rp_to_level": 1011, "mid_point": [2600000.5, 1199999.5]},
                 {"mh_id": "S", "rp_to_level": 1012, "mid_point": [2600000.5, 1200000.5]},
-            ]
+            ],
+            "output": [
+                {"mh_id": "W", "rp_from_level": 1010,"mid_point": [2599999.5,51200000]},
+            ],
         }
         self.insert_reaches(reaches, manholes)
         self.assertEqual(
             self.select("vw_tww_wastewater_structure", manholes["main"]["obj_id"])["_input_label"],
-            "\nI1=1012.00\nI2=1011.00",
+            "\nI1=1012.00\nI2=1012.00",
         )
 
 

--- a/datamodel/test/test_label.py
+++ b/datamodel/test/test_label.py
@@ -144,7 +144,7 @@ class TestViews(unittest.TestCase, DbTestBase):
         self.insert_reaches(reaches, manholes)
         self.assertEqual(
             self.select("vw_tww_wastewater_structure", manholes["main"]["obj_id"])["_input_label"],
-            "\nI1=1012.00\nI2=1012.00",
+            "\nI1=1011.00\nI2=1012.00",
         )
 
 

--- a/datamodel/test/test_label.py
+++ b/datamodel/test/test_label.py
@@ -144,7 +144,7 @@ class TestViews(unittest.TestCase, DbTestBase):
         self.insert_reaches(reaches, manholes)
         self.assertEqual(
             self.select("vw_tww_wastewater_structure", manholes["main"]["obj_id"])["_input_label"],
-            "\nI1=1011.00\nI2=1012.00",
+            "\nI1=1012.00\nI2=1011.00",
         )
 
 


### PR DESCRIPTION
The order of the labels is dependent on the orientation of the outflow. This PR adds an outflow to this test.