### PR TITLE
[WIP] Use oqtopus reusable workflows for datamodel dumps, project translations, and version check

### DIFF
--- a/.github/workflows/datamodel-dumps-documentation.yml
+++ b/.github/workflows/datamodel-dumps-documentation.yml
@@ -15,90 +15,21 @@ on:
       - datamodel/**
       - '.github/workflows/datamodel-dumps-documentation.yml'
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be called by other workflows
-      inputs:
-        release_tag:
-          required: false
-          description: 'Release tag to upload dumps as GitHub Release asset'
-          default: ''
-          type: string
-
+  workflow_call:
+    inputs:
+      release_tag:
+        required: false
+        description: 'Release tag to upload dumps as GitHub Release asset'
+        default: ''
+        type: string
 
 jobs:
   datamodel-dumps:
-    name: Create dumps and schemaspy of datamodel
-    runs-on: ubuntu-latest
-    env:
-      PGSERVICE: pg_tww
-      DB_NAME: tww
-      DEMO_DATA: Aletsch
-      COMPOSE_PROFILES: schemaspy
-      COMPOSE_PROJECT_NAME: wastewater
-
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup env
-        run: cp .env.example .env
-
-      - name: Initialize container
-        run: |
-          docker compose up -d --build
-          until docker compose exec db pg_isready -U postgres; do
-            echo "Waiting for PostgreSQL to be ready..."
-            sleep 3
-          done
-          docker compose exec db createdb -U postgres ${DB_NAME}
-          docker compose exec db createdb -U postgres ${DB_NAME}_demo
-          docker compose run pum -vvv -p ${PGSERVICE} -d datamodel install -p SRID 2056
-          docker compose run pum -vvv -p ${PGSERVICE}_demo -d datamodel install -p SRID 2056 --demo-data ${DEMO_DATA}
-
-      - name: Create dumps
-        run: |
-          VERSION=${{ inputs.release_tag || github.event.release.tag_name || 'dev' }}
-          docker compose exec db pg_dump -U postgres --format custom --exclude-schema=public --blobs --compress 5 --file /dump/${DB_NAME}-${VERSION}-db-dump.backup ${DB_NAME}
-          docker compose exec db pg_dump -U postgres --format plain --exclude-schema=public --file /dump/${DB_NAME}-${VERSION}-db-dump.sql ${DB_NAME}
-          docker compose exec db pg_dump -U postgres --format plain --schema=${DB_NAME}_app --file /dump/${DB_NAME}-${VERSION}-db-app.sql ${DB_NAME}
-          docker compose exec db pg_dump -U postgres --format custom --exclude-schema=public --blobs --compress 5 --file /dump/${DB_NAME}-${VERSION}-db-dump-with-demo.backup ${DB_NAME}_demo
-          docker compose exec db pg_dump -U postgres --format plain --exclude-schema=public --file /dump/${DB_NAME}-${VERSION}-db-dump-with-demo.sql ${DB_NAME}_demo
-          mkdir -p datamodel/artifacts/
-          docker compose cp db:/dump/. ./datamodel/artifacts/
-
-      - name: Schemaspy
-        run:  docker compose up schemaspy
-
-      - name: Docker logs
-        if: failure()
-        run: docker compose logs db
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: datamodel-dumps
-          path: datamodel/artifacts/
-          if-no-files-found: error
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: datamodel-schemaspy
-          path: datamodel/schemaspy/
-          if-no-files-found: error
-
-      - name: Zip datamodel dumps
-        run: |
-           zip -r datamodel-dumps.zip datamodel/artifacts
-
-      - name: Zip schemaspy output
-        run: zip -r datamodel-schemaspy.zip datamodel/schemaspy
-
-      - name: Upload datamodel dumps as GitHub Release asset
-        if: ${{ inputs.release_tag != '' }}
-        run: |
-          gh release upload "${{ inputs.release_tag }}" datamodel-dumps.zip --repo "$GITHUB_REPOSITORY"
-          gh release upload "${{ inputs.release_tag }}" datamodel-schemaspy.zip --repo "$GITHUB_REPOSITORY"
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+    uses: opengisch/oqtopus/.github/workflows/reusable-datamodel-dumps.yml@main
+    with:
+      pgservice: pg_tww
+      db_name: tww
+      demo_data: Aletsch
+      compose_project_name: wastewater
+      release_tag: ${{ inputs.release_tag }}
+    secrets: inherit

--- a/.github/workflows/datamodel-test.yml
+++ b/.github/workflows/datamodel-test.yml
@@ -22,44 +22,8 @@ on:
 
 jobs:
   version-tests:
-    if: github.event_name == 'pull_request'
-    name: Check versioning
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-
-      - name: Check changelog versions
-        run: |
-          LATEST_RELEASE=$(gh release view --json tagName -q .tagName | cut -d. -f1-2)
-          echo "Latest release: $LATEST_RELEASE"
-          if [ -z "$LATEST_RELEASE" ]; then
-            echo "No release found."
-            exit 1
-          fi
-
-          MODIFIED_FILES=$(git diff --name-only HEAD^1 HEAD)
-          echo "*** Modified files:"
-          echo "$MODIFIED_FILES"
-
-          MODIFIED_CHANGELOGS=$(echo "$MODIFIED_FILES" | grep "^datamodel/changelogs/" || true)
-          echo "Modified changelog files:"
-          echo "$MODIFIED_CHANGELOGS"
-
-          if [ -n "$MODIFIED_CHANGELOGS" ]; then
-            for file in $MODIFIED_CHANGELOGS; do
-              DIR=$(echo "$file" | cut -d'/' -f3)
-              if (( $(echo "$DIR <= ${LATEST_RELEASE}" | bc -l) )); then
-                echo "❌ Error: Changelogs are modified in an already existing release directory: $DIR"
-                exit 1
-              fi
-            done
-          fi
-          echo "✅ Changelog versions are valid"
+    uses: opengisch/oqtopus/.github/workflows/reusable-datamodel-version-check.yml@main
+    secrets: inherit
 
   datamodel-tests:
     name: Run unit tests on datamodel

--- a/.github/workflows/project-translation-package.yml
+++ b/.github/workflows/project-translation-package.yml
@@ -20,7 +20,7 @@ on:
   schedule:
     - cron: "30 04 * * *"
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be called by other workflows
+  workflow_call:
     inputs:
       release_tag:
         required: false
@@ -29,74 +29,13 @@ on:
         type: string
 
 jobs:
-  build:
-    name: Update project translations
-    runs-on: ubuntu-24.04
-
-    env:
-      TX_TOKEN: ${{ secrets.TX_TOKEN }}
-      COMPOSE_PROFILES: qgis
-      MODULE_NAME: tww
-      QGS_PROJECT_TITLE: TWW
-      QGS_PROJECT_FILE: teksi_wastewater
-      PGSERVICE: pg_tww
-      DB_NAME: tww
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install Transifex
-        working-directory: project
-        run: |
-          curl -OL https://github.com/transifex/cli/releases/download/v1.6.10/tx-linux-amd64.tar.gz
-          tar -xvzf tx-linux-amd64.tar.gz
-
-      - name: Start Docker compose
-        run: |
-          docker compose up --build -d
-          until docker compose exec db pg_isready -U postgres; do
-            echo "Waiting for PostgreSQL to be ready..."
-            sleep 2
-          done
-          docker compose exec db createdb -U postgres ${DB_NAME}
-          docker compose run pum -vvv -p ${PGSERVICE} -d datamodel install -p SRID 2056
-
-      - name: Translate (create sources)
-        run: docker compose exec qgis sh -c "xvfb-run /usr/src/project/scripts/project-translation-create-source.py /usr/src/project/${QGS_PROJECT_FILE}.qgs"
-
-      - name: Push to TX
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        working-directory: project
-        run: ./tx push --source
-
-      - name: Compile Translations (fetch translated content)
-        working-directory: project
-        run: |
-          ./tx pull -a
-          docker compose exec qgis sh -c "/usr/src/project/scripts/project-translation-compile.sh /usr/src/project/${QGS_PROJECT_FILE}.qgs"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: project-translations
-          path: project/${{ env.QGS_PROJECT_FILE }}*
-          if-no-files-found: error
-
-      - name: set project version + create project archive
-        run: |
-          sed -i "s|<title>${QGS_PROJECT_TITLE} - Demo</title>|<title>${QGS_PROJECT_TITLE} - v${{ github.event.release.tag_name }}</title>|" project/${QGS_PROJECT_FILE}.qgs
-          sed -i "s|projectname=\"${QGS_PROJECT_TITLE} - Demo\"|projectname=\"${QGS_PROJECT_TITLE} - v${{ github.event.release.tag_name }}\"|" project/${QGS_PROJECT_FILE}.qgs
-          sed "s/${PGSERVICE}/${PGSERVICE}_dev/g" project/${QGS_PROJECT_FILE}.qgs > project/${QGS_PROJECT_TITLE}_dev.qgs
-          sed "s/${PGSERVICE}/${PGSERVICE}_prod/g" project/${QGS_PROJECT_FILE}.qgs > project/${QGS_PROJECT_TITLE}_prod.qgs
-          zip -r ${MODULE_NAME}-${{ github.event.release.tag_name }}-project.zip project README.md
-
-      - name: Zip project translations
-        run: zip -r project-translations.zip project/${QGS_PROJECT_FILE}*
-
-      - name: Upload project translations as GitHub Release asset
-        if: ${{ inputs.release_tag != '' }}
-        run: |
-          gh release upload "${{ inputs.release_tag }}" project-translations.zip#oqtopus.project --repo "$GITHUB_REPOSITORY"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+  project-translation-package:
+    uses: opengisch/oqtopus/.github/workflows/reusable-project-translation-package.yml@main
+    with:
+      module_name: tww
+      qgs_project_file: teksi_wastewater
+      qgs_project_title: TWW
+      pgservice: pg_tww
+      db_name: tww
+      release_tag: ${{ inputs.release_tag }}
+    secrets: inherit


### PR DESCRIPTION
Replace inline workflow implementations with calls to centralized reusable workflows from opengisch/oqtopus:
- datamodel-dumps-documentation.yml → reusable-datamodel-dumps.yml
- project-translation-package.yml → reusable-project-translation-package.yml
- datamodel-test.yml version-tests job → reusable-datamodel-version-check.yml

Plugin packaging kept as-is (too project-specific for a reusable workflow).