### PR TITLE
Fix project open/close lifecycle in TWW plugin

### DIFF
--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -28,8 +28,8 @@ import logging
 import os
 import shutil
 
-from qgis.core import Qgis, QgsApplication
-from qgis.PyQt.QtCore import QLocale, QSettings, Qt
+from qgis.core import Qgis, QgsApplication, QgsProject
+from qgis.PyQt.QtCore import QLocale, QSettings, Qt, QTimer
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QApplication, QMessageBox, QToolBar
 from qgis.utils import qgsfunction
@@ -51,7 +51,7 @@ from .utils.database_utils import DatabaseUtils
 from .utils.plugin_utils import plugin_root_path
 from .utils.qt_utils import OverrideCursor
 from .utils.translation import setup_i18n
-from .utils.twwlayermanager import TwwLayerManager, TwwLayerNotifier
+from .utils.twwlayermanager import TwwLayerManager
 from .utils.twwlogging import TwwQgsLogHandler
 
 LOGFORMAT = "%(asctime)s:%(levelname)s:%(module)s:%(message)s"
@@ -165,14 +165,7 @@ class TeksiWastewaterPlugin:
         """
         Called to setup the plugin GUI
         """
-        self.network_layer_notifier = TwwLayerNotifier(
-            self.iface.mainWindow(),
-            ["vw_network_node", "vw_network_segment"],
-        )
-        self.vw_tww_layer_notifier = TwwLayerNotifier(
-            self.iface.mainWindow(),
-            ["vw_tww_wastewater_structure"],
-        )
+
         self.toolbarButtons = []
 
         # Create toolbar button
@@ -323,11 +316,8 @@ class TeksiWastewaterPlugin:
         self.toolbarButtons.append(self.importAction)
         self.toolbarButtons.append(self.exportAction)
 
-        self.network_layer_notifier.layersAvailable.connect(self.onNetworkLayersAvailable)
-        self.network_layer_notifier.layersUnavailable.connect(self.onNetworkLayersUnavailable)
-
-        self.vw_tww_layer_notifier.layersAvailable.connect(self.onTwwLayersAvailable)
-        self.vw_tww_layer_notifier.layersUnavailable.connect(self.onTwwLayersUnavailable)
+        QgsProject.instance().layerLoaded.connect(self._on_layer_loaded)
+        QgsProject.instance().cleared.connect(self._on_project_cleared)
 
         # Init the object maintaining the network
         self.network_analyzer = TwwGraphManager()
@@ -356,7 +346,8 @@ class TeksiWastewaterPlugin:
         self.processing_provider = TwwProcessingProvider()
         QgsApplication.processingRegistry().addProvider(self.processing_provider)
 
-        self.network_layer_notifier.layersAdded([])
+        # Handle the case where a project is already open when the plugin loads
+        self._check_tww_layers()
 
         self.selectionExtenderWidget = None
         self.selectionExtenderAction = QAction(
@@ -476,22 +467,48 @@ class TeksiWastewaterPlugin:
             self.selectionExtenderWidget.deleteLater()
             self.selectionExtenderWidget = None
 
-    def onNetworkLayersAvailable(self, layers):
+    def _on_layer_loaded(self, i, n):
+        """
+        Called during project loading for each layer. When the last layer is loaded,
+        schedule a deferred check so all C++ layer objects are fully constructed.
+        """
+        if i == n:
+            QTimer.singleShot(0, self._check_tww_layers)
+
+    def _on_project_cleared(self):
+        self._on_tww_project_unavailable()
+
+    def _check_tww_layers(self):
+        """
+        Checks whether a TWW project is available (i.e. some required TWW layers are present in the current project).
+        If so, enables the plugin.
+        """
+        required_layers = ["vw_network_node", "vw_network_segment", "vw_tww_wastewater_structure"]
+        all_layer_ids = list(QgsProject.instance().mapLayers().keys())
+
+        for tww_id in required_layers:
+            if not any(lyr_id.startswith(tww_id) for lyr_id in all_layer_ids):
+                return
+
+        self._on_tww_project_available()
+
+    def _on_tww_project_available(self):
+        network_segment = TwwLayerManager.layer("vw_network_segment")
+        network_node = TwwLayerManager.layer("vw_network_node")
+
         self.connectNetworkElementsAction.setEnabled(True)
-        self.network_analyzer.setReachLayer(layers["vw_network_segment"])
-        self.network_analyzer.setNodeLayer(layers["vw_network_node"])
+        self.network_analyzer.setLayers(network_segment, network_node)
 
-    def onNetworkLayersUnavailable(self):
-        self.connectNetworkElementsAction.setEnabled(False)
-
-    def onTwwLayersAvailable(self):
         for b in self.toolbarButtons:
             b.setEnabled(True)
 
         self._configure_database_connection_config_from_tww_layer()
         self.tww_validity_check_startup()
 
-    def onTwwLayersUnavailable(self):
+    def _on_tww_project_unavailable(self):
+        self.connectNetworkElementsAction.setEnabled(False)
+        self.network_analyzer.setLayers(None, None)
+
         for b in self.toolbarButtons:
             b.setEnabled(False)
 

--- a/plugin/teksi_wastewater/tools/twwnetwork.py
+++ b/plugin/teksi_wastewater/tools/twwnetwork.py
@@ -62,36 +62,18 @@ class TwwGraphManager(QObject):
     def __init__(self):
         QObject.__init__(self)
 
-    def setReachLayer(self, reach_layer):
+    def setLayers(self, reach_layer, node_layer):
         """
-        Set the reach layer (edges)
+        Set both the reach (edge) and node layers at the same time.
         """
         self.edge_layer = reach_layer
-        self.dirty = True
-
-        if reach_layer:
-            self.edge_layer_id = reach_layer.id()
-        else:
-            self.edge_layer_id = 0
-
-        if self.nodeLayer and self.edge_layer:
-            self.createGraph()
-
-    def setNodeLayer(self, node_layer):
-        """
-        Set the node layer
-        """
-        self.dirty = True
-
         self.nodeLayer = node_layer
+        self.dirty = True
 
-        if node_layer:
-            self.nodeLayerId = node_layer.id()
+        self.edge_layer_id = reach_layer.id() if reach_layer else -1
+        self.nodeLayerId = node_layer.id() if node_layer else -1
 
-        else:
-            self.nodeLayerId = 0
-
-        if self.nodeLayer and self.edge_layer:
+        if self.edge_layer and self.nodeLayer:
             self.createGraph()
 
     def _addVertices(self):

--- a/plugin/teksi_wastewater/utils/twwlayermanager.py
+++ b/plugin/teksi_wastewater/utils/twwlayermanager.py
@@ -3,67 +3,6 @@ This module helps managing the TWW project layers.
 """
 
 from qgis.core import QgsProject
-from qgis.PyQt.QtCore import QObject, pyqtSignal
-
-
-class TwwLayerNotifier(QObject):
-    """
-    This class sends out notification when a given set of layers is available or unavailable.
-    """
-
-    layersAvailable = pyqtSignal([dict])
-    layersUnavailable = pyqtSignal()
-
-    layersAvailableChanged = pyqtSignal(bool)
-
-    available = False
-
-    def __init__(self, parent, layers):
-        QObject.__init__(self, parent)
-        self.layers = layers
-
-        QgsProject.instance().layersWillBeRemoved.connect(self.layersWillBeRemoved)
-        QgsProject.instance().layersAdded.connect(self.layersAdded)
-
-    def layersWillBeRemoved(self, _):
-        """
-        Gets called when a layer is removed
-
-        @param _: The layers about to be removed
-        """
-
-        if self.available:
-            for tww_id in self.layers:
-                lyrs = [
-                    lyr
-                    for (lyr_id, lyr) in list(QgsProject.instance().mapLayers().items())
-                    if lyr_id.startswith(tww_id)
-                ]
-                if not lyrs:
-                    self.layersUnavailable.emit()
-                    self.layersAvailableChanged.emit(False)
-                    self.available = False
-
-    def layersAdded(self, _):
-        """
-        Gets called when a layer is added
-        @param _: the layers to check
-        """
-        if not self.available:
-            lyrlist = dict()
-            for tww_id in self.layers:
-                lyr = [
-                    lyr
-                    for (lyr_id, lyr) in list(QgsProject.instance().mapLayers().items())
-                    if lyr_id.startswith(tww_id)
-                ]
-                if not lyr:
-                    return
-                lyrlist[tww_id] = lyr[0]
-
-            self.available = True
-            self.layersAvailableChanged.emit(True)
-            self.layersAvailable.emit(lyrlist)
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
- Replace TwwLayerNotifier with direct QgsProject signals
- Use layerLoaded(i==n)+QTimer.singleShot for safe post-load check
- Use cleared signal for project close detection
- Merge setReachLayer/setNodeLayer into setLayers to avoid hybrid state

Fix #541