### PR TITLE
Fix integrity checker

### DIFF
--- a/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
+++ b/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
@@ -201,18 +201,21 @@ class TWWIntegrityChecker:
         """
         Returns a dict of {class_name: (count, [obj_ids])} for missing values.
         """
-
-        if not condition_parts:
+        
+        if not any((check_str, check_null, check_true)):
             raise ValueError("No conditions specified for check_conditions")
 
-        if check_val is None:
-            check_val = ""
+
         with DatabaseUtils.PsycopgConnection() as connection:
             cursor = connection.cursor()
             column_identifier = DatabaseUtils.wrap_identifier(value_name)
             condition_parts = []
             params = []
             if check_str:
+                
+                if check_val is None:
+                    raise ValueError("check_val must be provided when check_str=True")
+
                 condition_parts.append(
                     DatabaseUtils.compose_sql(
                         "{column_name} = %s",

--- a/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
+++ b/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
@@ -141,9 +141,6 @@ class TWWIntegrityChecker:
 
         with DatabaseUtils.PsycopgConnection() as connection:
             cursor = connection.cursor()
-
-            cursor.execute(f"SELECT obj_id FROM {schema_name}.{parent_name};")
-
             cursor.execute(f"SELECT obj_id FROM {schema_name}.{parent_name};")
             parent_rows = cursor.fetchall()
             parent_ids = {row[0] for row in parent_rows}
@@ -204,12 +201,17 @@ class TWWIntegrityChecker:
         """
         Returns a dict of {class_name: (count, [obj_ids])} for missing values.
         """
-        if not check_val:
+        
+        if not condition_parts:
+            raise ValueError("No conditions specified for check_conditions")
+
+        if check_val is None:
             check_val = ""
         with DatabaseUtils.PsycopgConnection() as connection:
             cursor = connection.cursor()
             column_identifier = DatabaseUtils.wrap_identifier(value_name)
             condition_parts = []
+            params = []
             if check_str:
                 condition_parts.append(
                     DatabaseUtils.compose_sql(
@@ -217,6 +219,7 @@ class TWWIntegrityChecker:
                         column_name=column_identifier,
                     )
                 )
+                params.append(check_val)
             if check_null:
                 condition_parts.append(
                     DatabaseUtils.compose_sql(
@@ -245,7 +248,7 @@ class TWWIntegrityChecker:
                     table_name=DatabaseUtils.wrap_identifier(_class),
                     condition=condition,
                 )
-                cursor.execute(query, (check_val,))
+                cursor.execute(query, params or None)
                 result = cursor.fetchone()
                 class_count = int(result[0]) if result else 0
                 obj_ids_without_val = result[1] if result else []

--- a/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
+++ b/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
@@ -194,14 +194,13 @@ class TWWIntegrityChecker:
         check_classes: list[str],
         value_name: str,
         check_val: Any = None,
-        check_str: bool = True,
         check_null: bool = True,
         check_true: bool = False,
     ) -> dict[str, tuple[int, list[Any]]]:
         """
         Returns a dict of {class_name: (count, [obj_ids])} for missing values.
         """
-
+        check_str = check_val is not None
         if not any((check_str, check_null, check_true)):
             raise ValueError("No conditions specified for check_conditions")
 
@@ -211,9 +210,6 @@ class TWWIntegrityChecker:
             condition_parts = []
             params = []
             if check_str:
-
-                if check_val is None:
-                    raise ValueError("check_val must be provided when check_str=True")
 
                 condition_parts.append(
                     DatabaseUtils.compose_sql(
@@ -262,7 +258,6 @@ class TWWIntegrityChecker:
         check_classes: list[str],
         value_name: str,
         check_val: Any = None,
-        check_str: bool = True,
         check_null: bool = True,
         check_true: bool = False,
     ) -> tuple[bool, str, int]:
@@ -275,7 +270,7 @@ class TWWIntegrityChecker:
         Returns: (failed, error_message, issue_count)
         """
         results = self._check_conditions(
-            check_classes, value_name, check_val, check_str, check_null, check_true
+            check_classes, value_name, check_val, check_null, check_true
         )
         error_message = ""
         empty_class_count = 0
@@ -341,7 +336,7 @@ class TWWIntegrityChecker:
 
     def _check_identifier_null(self):
         """
-        Check if attribute identifier is Null
+        Check if attribute identifier is Null or ''
         """
         check_classes = [
             ("organisation"),
@@ -427,7 +422,7 @@ class TWWIntegrityChecker:
                     ("zone"),
                 ]
             )
-        return self._check_value_condition(check_classes, "identifier")
+        return self._check_value_condition(check_classes, "identifier",'')
 
     def _check_fk_owner_null(self):
         """
@@ -871,7 +866,7 @@ class TWWIntegrityChecker:
         return self._check_available_export_values(
             check_classes,
             "tww_local_extension",
+            check_val=None,
             check_null=False,
-            check_str=False,
             check_true=True,
         )

--- a/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
+++ b/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
@@ -201,7 +201,7 @@ class TWWIntegrityChecker:
         """
         Returns a dict of {class_name: (count, [obj_ids])} for missing values.
         """
-        
+
         if not condition_parts:
             raise ValueError("No conditions specified for check_conditions")
 

--- a/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
+++ b/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
@@ -201,10 +201,9 @@ class TWWIntegrityChecker:
         """
         Returns a dict of {class_name: (count, [obj_ids])} for missing values.
         """
-        
+
         if not any((check_str, check_null, check_true)):
             raise ValueError("No conditions specified for check_conditions")
-
 
         with DatabaseUtils.PsycopgConnection() as connection:
             cursor = connection.cursor()
@@ -212,7 +211,7 @@ class TWWIntegrityChecker:
             condition_parts = []
             params = []
             if check_str:
-                
+
                 if check_val is None:
                     raise ValueError("check_val must be provided when check_str=True")
 

--- a/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
+++ b/plugin/teksi_wastewater/interlis/utils/interlis_integrity_checker.py
@@ -422,7 +422,7 @@ class TWWIntegrityChecker:
                     ("zone"),
                 ]
             )
-        return self._check_value_condition(check_classes, "identifier",'')
+        return self._check_value_condition(check_classes, "identifier", "")
 
     def _check_fk_owner_null(self):
         """


### PR DESCRIPTION
Running the integrity check `_check_organisation_tww_local_extension_count()` causes the following runtime error:
`psycopg.ProgrammingError: the query has 0 placeholders but 1 parameters were passed` (no separate Issue)

The root cause was in `_check_conditions()`:
- SQL conditions are built dynamically
- Parameters were always passed to `cursor.execute()`, even though some conditions (e.g. `IS NULL`, `IS True`) do not introduce SQL placeholders

The `_check_conditions() `method was refactored to build SQL and parameters together:

- Parameters are now added only when a `%s `placeholder is added to the SQL
- `cursor.execute()` is called with parameters only when needed