### PR TITLE
Improvements on network refresh

### DIFF
--- a/datamodel/app/sql_functions/network_functions.sql
+++ b/datamodel/app/sql_functions/network_functions.sql
@@ -1,10 +1,21 @@
 CREATE OR REPLACE FUNCTION tww_app.network_refresh_network_simple() RETURNS void SECURITY DEFINER AS $body$
+
+DECLARE
+  t0 timestamptz;
 BEGIN
+  t0 := clock_timestamp();
 
   TRUNCATE tww_od.network_segment CASCADE;
   TRUNCATE tww_od.network_node CASCADE;
 
   -- Insert wastewater nodes
+    PERFORM pg_notify(
+    'network_refresh',
+    json_build_object(
+      'step', 'nodes_wn',
+      'elapsed', extract(epoch from clock_timestamp() - t0)
+    )::text);
+  INSERT INTO t
   INSERT INTO tww_od.network_node(node_type, ne_id, geom)
   SELECT
     'wastewater_node',
@@ -13,6 +24,12 @@ BEGIN
   FROM tww_od.wastewater_node n;
 
 -- Insert reachpoints
+    PERFORM pg_notify(
+    'network_refresh',
+    json_build_object(
+      'step', 'nodes_rp',
+      'elapsed', extract(epoch from clock_timestamp() - t0)
+    )::text);
   INSERT INTO tww_od.network_node(node_type, ne_id, rp_id, geom)
   SELECT
     'reach_point',
@@ -24,6 +41,12 @@ BEGIN
   LEFT JOIN tww_od.reach r_t ON rp.obj_id = r_t.fk_reach_point_to;
 
   -- Insert virtual nodes for blind connections
+    PERFORM pg_notify(
+    'network_refresh',
+    json_build_object(
+      'step', 'nodes_blind',
+      'elapsed', extract(epoch from clock_timestamp() - t0)
+    )::text);
   INSERT INTO tww_od.network_node(node_type, ne_id, geom)
   SELECT DISTINCT
     'blind_connection',
@@ -40,6 +63,12 @@ BEGIN
 	NOT IN (0.0, 1.0); -- if exactly at start or at end, we don't need a virtualnode as we have the reachpoint
 
   -- Insert reaches, subdivided according to blind reaches
+    PERFORM pg_notify(
+    'network_refresh',
+    json_build_object(
+      'step', 'edges_re_blind',
+      'elapsed', extract(epoch from clock_timestamp() - t0)
+    )::text);
   INSERT INTO tww_od.network_segment (segment_type, from_node, to_node, ne_id, geom)
   SELECT 'reach',
          sub2.node_id_1,
@@ -69,6 +98,13 @@ BEGIN
   WHERE ratio_1 IS NOT NULL AND ratio_1 <> ratio_2;
 
   -- Insert edge between reachpoint (from) to the closest node belonging to the wasterwater network element
+  PERFORM pg_notify(
+    'network_refresh',
+    json_build_object(
+      'step', 'edges_rp_from',
+      'elapsed', extract(epoch from clock_timestamp() - t0)
+    )::text);
+  RAISE NOTICE 'step 5: inserting edges from rp_from in detail geom: %', clock_timestamp() - t0;
   INSERT INTO tww_od.network_segment (segment_type, from_node, to_node, geom)
   SELECT DISTINCT ON(n1.id)
          'special_structure',
@@ -87,9 +123,17 @@ BEGIN
   ) AS sub1
   JOIN tww_od.network_node as n1 ON n1.rp_id = rp_obj_id
   JOIN tww_od.network_node as n2 ON n2.ne_id = wwne_id
-  ORDER BY n1.id, ST_Distance(n1.geom, n2.geom);
+  ORDER BY n1.id, n1.geom <-> n2.geom;
 
   -- Insert edge between reachpoint (to) to the closest node belonging to the wasterwater network element
+  
+  PERFORM pg_notify(
+    'network_refresh',
+    json_build_object(
+      'step', 'edges_rp_to',
+      'elapsed', extract(epoch from clock_timestamp() - t0)
+    )::text);
+
   INSERT INTO tww_od.network_segment (segment_type, from_node, to_node, geom)
   SELECT DISTINCT ON(n1.id)
          'special_structure',
@@ -108,7 +152,7 @@ BEGIN
   ) AS sub1
   JOIN tww_od.network_node as n1 ON n1.rp_id = rp_obj_id
   JOIN tww_od.network_node as n2 ON n2.ne_id = wwne_id
-  ORDER BY n1.id, ST_Distance(n1.geom, n2.geom);
+  ORDER BY n1.id, n1.geom <-> n2.geom;
 
   PERFORM tww_app.refresh_materialized_views('tww_app',NULL,True);
 

--- a/datamodel/app/sql_functions/network_functions.sql
+++ b/datamodel/app/sql_functions/network_functions.sql
@@ -15,7 +15,6 @@ BEGIN
       'step', 'nodes_wn',
       'elapsed', extract(epoch from clock_timestamp() - t0)
     )::text);
-  INSERT INTO t
   INSERT INTO tww_od.network_node(node_type, ne_id, geom)
   SELECT
     'wastewater_node',
@@ -104,7 +103,6 @@ BEGIN
       'step', 'edges_rp_from',
       'elapsed', extract(epoch from clock_timestamp() - t0)
     )::text);
-  RAISE NOTICE 'step 5: inserting edges from rp_from in detail geom: %', clock_timestamp() - t0;
   INSERT INTO tww_od.network_segment (segment_type, from_node, to_node, geom)
   SELECT DISTINCT ON(n1.id)
          'special_structure',
@@ -154,7 +152,8 @@ BEGIN
   JOIN tww_od.network_node as n2 ON n2.ne_id = wwne_id
   ORDER BY n1.id, n1.geom <-> n2.geom;
 
-  PERFORM tww_app.refresh_materialized_views('tww_app',NULL,True);
+  PERFORM tww_app.refresh_materialized_views('tww_app','vw_network_node');
+  PERFORM tww_app.refresh_materialized_views('tww_app','vw_network_segment');
 
 END;
 $body$

--- a/datamodel/app/sql_functions/network_functions.sql
+++ b/datamodel/app/sql_functions/network_functions.sql
@@ -126,7 +126,7 @@ BEGIN
   ORDER BY n1.id, n1.geom <-> n2.geom;
 
   -- Insert edge between reachpoint (to) to the closest node belonging to the wasterwater network element
-  
+
   PERFORM pg_notify(
     'network_refresh',
     json_build_object(

--- a/plugin/teksi_wastewater/teksi_wastewater_plugin.py
+++ b/plugin/teksi_wastewater/teksi_wastewater_plugin.py
@@ -246,6 +246,11 @@ class TeksiWastewaterPlugin:
         )
         self.disableSymbologyTriggersAction.triggered.connect(self.disable_symbology_triggers)
 
+        self.refreshmaterializedViewsAction = QAction(
+            self.tr("Refresh materialized views"), self.iface.mainWindow()
+        )
+        self.refreshmaterializedViewsAction.triggered.connect(self.refresh_materialized_views)
+
         self.settingsAction = QAction(
             QIcon(QgsApplication.getThemeIcon("/mActionOptions.svg")),
             self.tr("Settings"),
@@ -296,6 +301,7 @@ class TeksiWastewaterPlugin:
         self.iface.addPluginToMenu(self.main_menu_name, self.validityCheckAction)
         self.iface.addPluginToMenu(self.main_menu_name, self.enableSymbologyTriggersAction)
         self.iface.addPluginToMenu(self.main_menu_name, self.disableSymbologyTriggersAction)
+        self.iface.addPluginToMenu(self.main_menu_name, self.refreshmaterializedViewsAction)
         self.iface.addPluginToMenu(self.main_menu_name, self.settingsAction)
         self.iface.addPluginToMenu(self.main_menu_name, self.aboutAction)
 
@@ -433,6 +439,22 @@ class TeksiWastewaterPlugin:
                 self.tr(f"Symbology triggers cannot be disabled:\n\n{exception}"),
             )
 
+    def refresh_materialized_views(self):
+        try:
+            DatabaseUtils.refresh_matviews()
+            QMessageBox.information(
+                self.iface.mainWindow(),
+                self.refreshmaterializedViewsAction.text(),
+                self.tr("Materialized views have been successfully refreshed"),
+            )
+
+        except Exception as exception:
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                self.refreshmaterializedViewsAction.text(),
+                self.tr(f"Materialized views cannot be refreshed:\n\n{exception}"),
+            )
+
     def unload(self):
         """
         Called when unloading
@@ -459,6 +481,7 @@ class TeksiWastewaterPlugin:
         self.iface.removePluginMenu(self.main_menu_name, self.aboutAction)
         self.iface.removePluginMenu(self.main_menu_name, self.enableSymbologyTriggersAction)
         self.iface.removePluginMenu(self.main_menu_name, self.disableSymbologyTriggersAction)
+        self.iface.removePluginMenu(self.main_menu_name, self.refreshmaterializedViewsAction)
 
         QgsApplication.processingRegistry().removeProvider(self.processing_provider)
 
@@ -769,6 +792,7 @@ class TeksiWastewaterPlugin:
 
         self.enableSymbologyTriggersAction.setEnabled(admin_mode)
         self.disableSymbologyTriggersAction.setEnabled(admin_mode)
+        self.refreshmaterializedViewsAction.setEnabled(admin_mode)
 
     def toggleSelectionExtenderWidget(self, checked: bool):
         if checked:

--- a/plugin/teksi_wastewater/tools/twwnetwork.py
+++ b/plugin/teksi_wastewater/tools/twwnetwork.py
@@ -144,7 +144,7 @@ class TwwGraphManager(QObject):
         """
         try:
             with OverrideCursor(Qt.CursorShape.WaitCursor):
-                DatabaseUtils.refresh_matviews()
+                DatabaseUtils.refresh_network_simple()
             self.message_emitted.emit(
                 self.tr("Success"),
                 self.tr("Materialized Views successfully updated"),

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -269,7 +269,7 @@ class DatabaseUtils:
     def refresh_network_simple():
         logger.info("Refreshing network")
         DatabaseUtils.execute("SELECT tww_app.network_refresh_network_simple();")
-        
+
     @staticmethod
     def refresh_matviews():
         logger.info("Refreshing materialized views")

--- a/plugin/teksi_wastewater/utils/database_utils.py
+++ b/plugin/teksi_wastewater/utils/database_utils.py
@@ -266,6 +266,11 @@ class DatabaseUtils:
         return messages
 
     @staticmethod
+    def refresh_network_simple():
+        logger.info("Refreshing network")
+        DatabaseUtils.execute("SELECT tww_app.network_refresh_network_simple();")
+        
+    @staticmethod
     def refresh_matviews():
         logger.info("Refreshing materialized views")
-        DatabaseUtils.execute("SELECT tww_app.network_refresh_network_simple();")
+        DatabaseUtils.execute("PERFORM tww_app.refresh_materialized_views('tww_app', NULL, True);")


### PR DESCRIPTION
This PR adds the following improvements to the network refresh

- Raise timestamps usibg pg_notify (can be included into ui later)
- order by geometry distance by gist instead of postgis functions (uses indexes)
- refreshing the network materialized views does no longer update all materialized views, but only the network ones. The others are refreshed separately