### PR TITLE
use wastewater node identifiers in reach wizard identifier creation

### DIFF
--- a/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
+++ b/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
@@ -360,9 +360,8 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
                     else:
                         f.setAttribute(idx, self.layer.dataProvider().defaultValue(idx))
 
-
-            from_lbl = self.get_rp_identifier_from_match('from',f)
-            to_lbl   = self.get_rp_identifier_from_match('to', f)
+            from_lbl = self.get_rp_identifier_from_match("from", f)
+            to_lbl = self.get_rp_identifier_from_match("to", f)
 
             if from_lbl and to_lbl:
                 identifier = f"{from_lbl}-{to_lbl}"
@@ -409,10 +408,10 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
         self.rubberband.reset3D()
 
     def get_rp_identifier_from_match(self, idx, feat):
-        if idx=='from':
-            match=self.first_snapping_match
-        elif idx=='to':
-            match=self.last_snapping_match
+        if idx == "from":
+            match = self.first_snapping_match
+        elif idx == "to":
+            match = self.last_snapping_match
         else:
             return None
 
@@ -421,9 +420,8 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
             network_element = next(self.node_layer.getFeatures(request))
             assert network_element.isValid()
             return network_element.attribute("identifier")
-        else: # no valid match or reach-reach connection
+        else:  # no valid match or reach-reach connection
             return feat.attribute(f"rp_{idx}_obj_id")
-
 
 
 class TwwMapToolDigitizeDrainageChannel(QgsMapTool):

--- a/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
+++ b/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
@@ -369,7 +369,6 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
             else:
                 identifier = f.attribute("obj_id")
             field = self.layer.fields().indexFromName("identifier")
-            if
             f.setAttribute(field, identifier)
 
             f.setGeometry(self.rubberband.asGeometry3D())

--- a/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
+++ b/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
@@ -322,7 +322,7 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
         The party is over, the reach digitized. Create a feature from the rubberband and
         show the feature form.
         """
-        
+
         self.temp_rubberband.reset()
 
         if self.snapping_marker is not None:
@@ -369,7 +369,7 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
             else:
                 identifier = f.attribute("obj_id")
             field = self.layer.fields().indexFromName("identifier")
-            if 
+            if
             f.setAttribute(field, identifier)
 
             f.setGeometry(self.rubberband.asGeometry3D())
@@ -416,7 +416,7 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
             match=self.last_snapping_match
         else:
             return None
-        
+
         if match.isValid() and match.layer() == self.node_layer:
             request = QgsFeatureRequest(match.featureId())
             network_element = next(self.node_layer.getFeatures(request))
@@ -424,7 +424,7 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
             return network_element.attribute("identifier")
         else: # no valid match or reach-reach connection
             return feat.attribute(f"rp_{idx}_obj_id")
-      
+
 
 
 class TwwMapToolDigitizeDrainageChannel(QgsMapTool):

--- a/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
+++ b/plugin/teksi_wastewater/tools/twwmaptooladdfeature.py
@@ -322,6 +322,7 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
         The party is over, the reach digitized. Create a feature from the rubberband and
         show the feature form.
         """
+        
         self.temp_rubberband.reset()
 
         if self.snapping_marker is not None:
@@ -350,6 +351,7 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
                     "remark",
                 ]:
                     f.setAttribute(idx, self.last_feature_attributes[idx])
+
                 else:
                     # try client side default value first
                     v = self.layer.defaultValue(idx, f)
@@ -357,6 +359,18 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
                         f.setAttribute(idx, v)
                     else:
                         f.setAttribute(idx, self.layer.dataProvider().defaultValue(idx))
+
+
+            from_lbl = self.get_rp_identifier_from_match('from',f)
+            to_lbl   = self.get_rp_identifier_from_match('to', f)
+
+            if from_lbl and to_lbl:
+                identifier = f"{from_lbl}-{to_lbl}"
+            else:
+                identifier = f.attribute("obj_id")
+            field = self.layer.fields().indexFromName("identifier")
+            if 
+            f.setAttribute(field, identifier)
 
             f.setGeometry(self.rubberband.asGeometry3D())
 
@@ -394,6 +408,23 @@ class TwwMapToolAddReach(TwwMapToolAddFeature):
             self.last_feature_attributes = dlg.feature().attributes()
 
         self.rubberband.reset3D()
+
+    def get_rp_identifier_from_match(self, idx, feat):
+        if idx=='from':
+            match=self.first_snapping_match
+        elif idx=='to':
+            match=self.last_snapping_match
+        else:
+            return None
+        
+        if match.isValid() and match.layer() == self.node_layer:
+            request = QgsFeatureRequest(match.featureId())
+            network_element = next(self.node_layer.getFeatures(request))
+            assert network_element.isValid()
+            return network_element.attribute("identifier")
+        else: # no valid match or reach-reach connection
+            return feat.attribute(f"rp_{idx}_obj_id")
+      
 
 
 class TwwMapToolDigitizeDrainageChannel(QgsMapTool):


### PR DESCRIPTION
This pull request improves the reach digitizing workflow by adding client-side identifier generation in QGIS. The identifier is derived during digitizing from the snapping results of the start and end points. 

If snapping does not resolve to nodes, the logic falls back to the prefilled reach point object IDs allowing the workflow to remain functional for incomplete topology or reach-to-reach connections. If no valid values are available, the identifier defaults to reach.obj_id.

Uniqueness must be enforced via QGIS constraints, i.e. for parallel reaches.