### PR TITLE
Restore documentation structure with version/language

### DIFF
--- a/.github/workflows/docs-builder.yml
+++ b/.github/workflows/docs-builder.yml
@@ -148,7 +148,7 @@ jobs:
           echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
 
 
-      - name: build documentation
+      - name: Build documentation
         working-directory: docs
         run: |
           make html BUILDDIR=build/$DOCS_VERSION

--- a/.github/workflows/docs-builder.yml
+++ b/.github/workflows/docs-builder.yml
@@ -151,7 +151,7 @@ jobs:
       - name: build documentation
         working-directory: docs
         run: |
-          make html BUILDDIR=build/html/$DOCS_VERSION
+          make html BUILDDIR=build/$DOCS_VERSION
 
           for LANG in $LANGUAGES; do
             test -f ./build/html/$DOCS_VERSION/$LANG/index.html || (echo "Missing index for $LANG" && exit 1)

--- a/.github/workflows/docs-builder.yml
+++ b/.github/workflows/docs-builder.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Build documentation
         working-directory: docs
         run: |
-          make html BUILDDIR=build/$DOCS_VERSION
+          make html
 
           for LANG in $LANGUAGES; do
             test -f ./build/html/$DOCS_VERSION/$LANG/index.html || (echo "Missing index for $LANG" && exit 1)

--- a/.github/workflows/docs-builder.yml
+++ b/.github/workflows/docs-builder.yml
@@ -151,7 +151,7 @@ jobs:
       - name: build documentation
         working-directory: docs
         run: |
-          make html
+          make html BUILDDIR=build/html/$DOCS_VERSION
 
           for LANG in $LANGUAGES; do
             test -f ./build/html/$DOCS_VERSION/$LANG/index.html || (echo "Missing index for $LANG" && exit 1)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -125,8 +125,8 @@ html: compile_messages
 		  mkdir -p $(BUILDDIR)/doctrees/$$lang; \
 			$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/html/$$lang; \
 		else \
-		  if [[ "$(TRANSLATIONS_I18N)" =~ "$$lang" ]]; then \
-				$(SPHINXBUILD) -b html $(ALLSPHINXOPTSI18N) en build/html/$$lang; \
+		if [[ "$(TRANSLATIONS_I18N)" =~ "$$lang" ]]; then \
+				$(SPHINXBUILD) -b html $(ALLSPHINXOPTSI18N) en $(BUILDDIR)/html/$$lang; \
 			fi \
 		fi \
 	done

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -140,7 +140,7 @@ gettext:
 	@echo "Build finished. The pot files pages are in i18n/pot.";\
 
 singlehtml: compile_messages
-	@set -e; for lang in en $(TRANSLATIONS_STATIC);\
+	@set -e; for lang in $(TRANSLATIONS_STATIC);\
 	do \
 		mkdir -p $(BUILDDIR)/singlehtml/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/singlehtml/$$lang;\
@@ -154,7 +154,7 @@ singlehtml: compile_messages
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/singlehtml/<language>.";\
 
 pickle: compile_messages
-	@set -e; for lang in en $(TRANSLATIONS_STATIC);\
+	@set -e; for lang in $(TRANSLATIONS_STATIC);\
 	do \
 		mkdir -p $(BUILDDIR)/pickle/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/pickle/$$lang;\
@@ -170,7 +170,7 @@ pickle: compile_messages
 web: pickle
 
 json: compile_messages
-	@set -e; for lang in en $(TRANSLATIONS_STATIC);\
+	@set -e; for lang in $(TRANSLATIONS_STATIC);\
 	do \
 		mkdir -p $(BUILDDIR)/json/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/json/$$lang;\
@@ -184,7 +184,7 @@ json: compile_messages
 	@echo "Build finished; now you can process the JSON files."
 
 htmlhelp: compile_messages
-	@set -e; for lang in en $(TRANSLATIONS_STATIC);\
+	@set -e; for lang in $(TRANSLATIONS_STATIC);\
 	do \
 		mkdir -p $(BUILDDIR)/htmlhelp/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/htmlhelp/$$lang;\

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,6 +5,10 @@
 
 # You can set these variables from the command line.
 BUILDDIR     = build
+# Optional version subfolder for multi-version output. When DOCS_VERSION is set
+# (e.g. by CI), HTML is built under $(BUILDDIR)/html/$(DOCS_VERSION)/<language>.
+# When unset, HTML is built directly under $(BUILDDIR)/html/<language>.
+HTMLDIR      = $(BUILDDIR)/html$(if $(DOCS_VERSION),/$(DOCS_VERSION))
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         = a4
@@ -19,7 +23,7 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees/$$lang $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c . -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)'
 
-ALLSPHINXOPTSI18N = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c . -a -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)'
+ALLSPHINXOPTSI18N = -d $(BUILDDIR)/doctrees/$$lang $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c . -a -A language=$$lang -D language=$$lang -A languages='$(LANGUAGES)'
 
 # Only for Gettext
 I18NSPHINXOPTS   = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c . -A language=en -D language=en -A languages='en'
@@ -115,22 +119,22 @@ compile_messages: init
 html: compile_messages
 	@set -e; \
 	lang=en; \
-	mkdir -p $(BUILDDIR)/html $(BUILDDIR)/doctrees/$$lang; \
-	echo $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/html; \
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/html; \
+	mkdir -p $(HTMLDIR) $(BUILDDIR)/doctrees/$$lang; \
+	echo $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(HTMLDIR); \
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(HTMLDIR); \
 	for lang in $(BUILD_LANGUAGES); \
 	do \
-		mkdir -p $(BUILDDIR)/html/$$lang $(BUILDDIR)/doctrees/$$lang; \
+		mkdir -p $(HTMLDIR)/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		if [[ "$(TRANSLATIONS_STATIC)" =~ "$$lang" ]]; then \
 		  mkdir -p $(BUILDDIR)/doctrees/$$lang; \
-			$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/html/$$lang; \
+			$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(HTMLDIR)/$$lang; \
 		else \
 		if [[ "$(TRANSLATIONS_I18N)" =~ "$$lang" ]]; then \
-				$(SPHINXBUILD) -b html $(ALLSPHINXOPTSI18N) en $(BUILDDIR)/html/$$lang; \
+				$(SPHINXBUILD) -b html $(ALLSPHINXOPTSI18N) en $(HTMLDIR)/$$lang; \
 			fi \
 		fi \
 	done
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/<language>.";
+	@echo "Build finished. The HTML pages are in $(HTMLDIR)/<language>.";
 
 gettext:
 		mkdir -p $(BUILDDIR)/gettext/en $(BUILDDIR)/doctrees/en; \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -118,15 +118,10 @@ compile_messages: init
 
 html: compile_messages
 	@set -e; \
-	lang=en; \
-	mkdir -p $(HTMLDIR) $(BUILDDIR)/doctrees/$$lang; \
-	echo $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(HTMLDIR); \
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(HTMLDIR); \
 	for lang in $(BUILD_LANGUAGES); \
 	do \
 		mkdir -p $(HTMLDIR)/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		if [[ "$(TRANSLATIONS_STATIC)" =~ "$$lang" ]]; then \
-		  mkdir -p $(BUILDDIR)/doctrees/$$lang; \
 			$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $$lang $(HTMLDIR)/$$lang; \
 		else \
 		if [[ "$(TRANSLATIONS_I18N)" =~ "$$lang" ]]; then \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -145,7 +145,7 @@ singlehtml: compile_messages
 		mkdir -p $(BUILDDIR)/singlehtml/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/singlehtml/$$lang;\
 	done
-	@set -e; for lang in $(TRANSLATIONI18N);\
+	@set -e; for lang in $(TRANSLATIONS_I18N);\
 	do \
 		mkdir -p $(BUILDDIR)/singlehtml/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTSI18N) en $(BUILDDIR)/singlehtml/$$lang;\
@@ -159,7 +159,7 @@ pickle: compile_messages
 		mkdir -p $(BUILDDIR)/pickle/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/pickle/$$lang;\
 	done
-	@set -e; for lang in $(TRANSLATIONI18N);\
+	@set -e; for lang in $(TRANSLATIONS_I18N);\
 	do \
 		mkdir -p $(BUILDDIR)/pickle/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTSI18N) en $(BUILDDIR)/pickle/$$lang;\
@@ -175,7 +175,7 @@ json: compile_messages
 		mkdir -p $(BUILDDIR)/json/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $$lang $(BUILDDIR)/json/$$lang;\
 	done
-	@set -e; for lang in $(TRANSLATIONI18N);\
+	@set -e; for lang in $(TRANSLATIONS_I18N);\
 	do \
 		mkdir -p $(BUILDDIR)/json/$$lang $(BUILDDIR)/doctrees/$$lang; \
 		$(SPHINXBUILD) -b json $(ALLSPHINXOPTSI18N) en $(BUILDDIR)/json/$$lang;\


### PR DESCRIPTION
```bash
[] ~/Downloads/documentation(7) tree -L 2
.
├── index.html
├── latest
│   ├── de
│   ├── en
│   ├── fr
│   └── _static
├── versions.json
└── versions.txt
```