### PR TITLE
202620260831-add-xtflog-path

### DIFF
--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -432,9 +432,9 @@ class InterlisImporterExporter:
 
     def _import_validate_xtf_file(self, xtf_file_input):
         log_path = make_log_path(self.base_log_path, "ilivalidator")
-        
+
         xtflog_path = make_xtflog_path(self.base_log_path, "ilivalidator")
-        
+
         try:
             self.interlisTools.validate_xtf_data(
                 xtf_file_input,
@@ -697,9 +697,9 @@ class InterlisImporterExporter:
                 f"Validating XTF for '{export_model_name}'...",
             )
             log_path = make_log_path(self.base_log_path, f"ilivalidator-{export_model_name}")
-            
+
             xtflog_path = make_xtflog_path(self.base_log_path, f"ilivalidator-{export_model_name}")
-            
+
             try:
                 self.interlisTools.validate_xtf_data(
                     export_file_name,

--- a/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
+++ b/plugin/teksi_wastewater/interlis/interlis_importer_exporter.py
@@ -36,6 +36,7 @@ from .utils.various import (
     LoggingHandlerContext,
     logger,
     make_log_path,
+    make_xtflog_path,
 )
 
 
@@ -431,10 +432,14 @@ class InterlisImporterExporter:
 
     def _import_validate_xtf_file(self, xtf_file_input):
         log_path = make_log_path(self.base_log_path, "ilivalidator")
+        
+        xtflog_path = make_xtflog_path(self.base_log_path, "ilivalidator")
+        
         try:
             self.interlisTools.validate_xtf_data(
                 xtf_file_input,
                 log_path,
+                xtflog_path,
             )
         except CmdException:
             raise InterlisImporterExporterError(
@@ -692,10 +697,14 @@ class InterlisImporterExporter:
                 f"Validating XTF for '{export_model_name}'...",
             )
             log_path = make_log_path(self.base_log_path, f"ilivalidator-{export_model_name}")
+            
+            xtflog_path = make_xtflog_path(self.base_log_path, f"ilivalidator-{export_model_name}")
+            
             try:
                 self.interlisTools.validate_xtf_data(
                     export_file_name,
                     log_path,
+                    xtflog_path,
                 )
             except CmdException:
                 xtf_export_errors.append(

--- a/plugin/teksi_wastewater/interlis/utils/ili2db.py
+++ b/plugin/teksi_wastewater/interlis/utils/ili2db.py
@@ -81,7 +81,7 @@ class InterlisTools:
     def validate_xtf_data(self, xtf_file, log_path, xtflog_path):
         logger.info("VALIDATING XTF DATA...")
         execute_subprocess(
-            f'"{self.java_executable_path}" -jar "{config.ILIVALIDATOR}" --log "{log_path}" --xtflog  "{xtflog_path}" "{xtf_file}"'
+            f'"{self.java_executable_path}" -jar "{config.ILIVALIDATOR}" --verbose --trace --log "{log_path}" --xtflog  "{xtflog_path}" "{xtf_file}"'
         )
 
     def import_xtf_data(self, schema, xtf_file, log_path, srid=2056):

--- a/plugin/teksi_wastewater/interlis/utils/ili2db.py
+++ b/plugin/teksi_wastewater/interlis/utils/ili2db.py
@@ -78,10 +78,10 @@ class InterlisTools:
             )
         )
 
-    def validate_xtf_data(self, xtf_file, log_path):
+    def validate_xtf_data(self, xtf_file, log_path, xtflog_path):
         logger.info("VALIDATING XTF DATA...")
         execute_subprocess(
-            f'"{self.java_executable_path}" -jar "{config.ILIVALIDATOR}" --log "{log_path}" "{xtf_file}"'
+            f'"{self.java_executable_path}" -jar "{config.ILIVALIDATOR}" --log "{log_path}" --xtflog  "{xtflog_path}" "{xtf_file}"'
         )
 
     def import_xtf_data(self, schema, xtf_file, log_path, srid=2056):

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -90,7 +90,16 @@ def make_log_path(next_to_path, step_name):
         os.makedirs(temp_path, exist_ok=True)
         return os.path.join(temp_path, f"{now}.{step_name}.log")
 
-
+def make_xtflog_path(next_to_path, step_name):
+    """Returns a path for xtf logging purposes. If next_to_path is None, it will be saved in the temp directory"""
+    now = f"{datetime.datetime.now():%y%m%d%H%M%S}"
+    if next_to_path:
+        return f"{next_to_path}.{now}.{step_name}.log.xtf"
+    else:
+        temp_path = os.path.join(tempfile.gettempdir(), "tww2ili")
+        os.makedirs(temp_path, exist_ok=True)
+        return os.path.join(temp_path, f"{now}.{step_name}.log.xtf")
+        
 class LoggingHandlerContext:
     """Temporarily sets a log handler, then removes it"""
 

--- a/plugin/teksi_wastewater/interlis/utils/various.py
+++ b/plugin/teksi_wastewater/interlis/utils/various.py
@@ -90,6 +90,7 @@ def make_log_path(next_to_path, step_name):
         os.makedirs(temp_path, exist_ok=True)
         return os.path.join(temp_path, f"{now}.{step_name}.log")
 
+
 def make_xtflog_path(next_to_path, step_name):
     """Returns a path for xtf logging purposes. If next_to_path is None, it will be saved in the temp directory"""
     now = f"{datetime.datetime.now():%y%m%d%H%M%S}"
@@ -99,7 +100,8 @@ def make_xtflog_path(next_to_path, step_name):
         temp_path = os.path.join(tempfile.gettempdir(), "tww2ili")
         os.makedirs(temp_path, exist_ok=True)
         return os.path.join(temp_path, f"{now}.{step_name}.log.xtf")
-        
+
+
 class LoggingHandlerContext:
     """Temporarily sets a log handler, then removes it"""
 


### PR DESCRIPTION
This pull request adds the xtf error log of ilivalidator also (not only the --log version, so that you can directly use the [updated QGIS XTFlogChecker plugin](https://github.com/geowerkstatt/qgis-xtf-log-checker/issues/20) to visualize the errors

See https://github.com/claeis/ilivalidator/blob/master/docs/ilivalidator.rst

<html><body>
<!--StartFragment-->

--log filename | Schreibt die log-Meldungen in eine Text-Datei.



--xtflog filename | Schreibt die log-Meldungen in eine INTERLIS 2-Datei.  Die Datei result.xtf entspricht dem Modell IliVErrors.



<!--EndFragment-->
</body>
</html>