### PR TITLE
Fix Standardoid handling in gep view

### DIFF
--- a/datamodel/app/view/gep_views/vw_catchment_area_totals_aggregated.sql
+++ b/datamodel/app/view/gep_views/vw_catchment_area_totals_aggregated.sql
@@ -22,7 +22,7 @@ CREATE MATERIALIZED VIEW tww_app.vw_catchment_area_totals_aggregated AS
         SELECT
           obj_id,
           fk_next_special_building,
-          ARRAY[obj_id::varchar]::varchar(16)[] AS log_card_path
+          ARRAY[obj_id::tww_od.interlis_standardoid]::tww_od.interlis_standardoid[] AS log_card_path
         FROM
           tww_od.log_card
         WHERE
@@ -33,7 +33,7 @@ CREATE MATERIALIZED VIEW tww_app.vw_catchment_area_totals_aggregated AS
         SELECT
           lc.obj_id,
           lc.fk_next_special_building,
-          (lt.log_card_path || lc.obj_id)::varchar(16)[]
+          (lt.log_card_path || lc.obj_id)::tww_od.interlis_standardoid[]
         FROM
           tww_od.log_card lc
         JOIN


### PR DESCRIPTION
Upgrade to 2026.1.0 failed for me due to a cast mismatch (might have to do with being on an older pg version) but ran through after this fix