### PR TITLE
Insert data_media via vw_file

### DIFF
--- a/datamodel/app/view/varia/vw_file.sql
+++ b/datamodel/app/view/varia/vw_file.sql
@@ -22,7 +22,7 @@ CREATE OR REPLACE VIEW tww_app.vw_file AS
     f.object,
     f.classname,
     -- dm.path,
-    COALESCE(dm.path::text || f.path_relative::text, f.path_relative::text) AS _url,
+    COALESCE(dm.path::text ||'/'|| f.path_relative::text, f.path_relative::text) AS _url,
     f.fk_dataowner as dataowner,
     f.fk_provider as provider,
     f.remark
@@ -56,10 +56,49 @@ COST 100;
 CREATE OR REPLACE FUNCTION tww_app.vw_file_insert()
   RETURNS trigger AS
 $BODY$
-
+DECLARE
+  dm_oid varchar(16);
+  dm_path str;
+  relative_path str;
   BEGIN
 
     NEW._url = replace(NEW._url, '\', '/');
+
+    SELECT obj_id, "path" INTO dm_oid, dm_path 
+    FROM tww_od.data_media
+    WHERE "path" = SUBSTRING(NEW._url FROM 1 FOR LENGTH("path"))
+    ORDER BY LENGTH("path") DESC
+    LIMIT 1;
+    IF NOT FOUND THEN
+      dm_path :=
+        CASE
+          WHEN NEW._url ~* '^https?://' THEN
+            regexp_replace(NEW._url,'^((https?://[^/]+/[^/]+)).*$','\1')
+
+          WHEN NEW._url ~ '^//[^/]+/' THEN
+            regexp_replace(NEW._url,'^((//[^/]+/[^/]+)).*$','\1')
+
+          WHEN NEW._url ~ '^[A-Za-z]:/' THEN
+            regexp_replace(NEW._url,'^(([A-Za-z]:)).*$','\1')
+
+          ELSE
+            regexp_replace(NEW._url,'^((/[^/]+)).*$','\1')
+        END;
+      INSERT INTO tww_od.data_media("path", kind, fk_dataowner, fk_provider) VALUES
+      (
+        dm_path,
+        CASE
+          WHEN url ~* '^https?://' THEN 9318 -- webserver
+          WHEN url ~ '^\\\\' THEN 3789       -- server
+          ELSE 3788                          -- harddisc
+        END,
+        NEW.dataowner,
+        NEW.provider)
+      RETURNING obj_id
+      INTO dm_oid;
+    END IF;
+
+    relative_path :=ltrim(substring(NEW._url from length(dm_path) + 1),'/');
 
     INSERT INTO tww_od.file(
       classname,
@@ -71,27 +110,16 @@ $BODY$
       fk_provider,
       fk_data_media,
       remark)
-
-    SELECT
+  VALUES(
       NEW.classname,
       NEW.identifier,
       NEW.kind,
       NEW.object,
-      SUBSTRING(NEW._url, LENGTH("path")+1, LENGTH(NEW._url)), -- path_relative,
+      relative_path, -- path_relative,
       NEW.dataowner, -- fk_dataowner,
       NEW.provider, -- fk_provider,
-      obj_id, -- fk_data_media
-      NEW.remark
-    FROM tww_od.data_media
-    WHERE "path" = SUBSTRING(NEW._url FROM 1 FOR LENGTH("path"))
-    ORDER BY LENGTH("path") DESC
-    LIMIT 1;
-
-    -- FOUND is a special variable which is always FALSE at the beginning of a PL/pgsql function and will be set by
-    -- e.g. INSERT to TRUE if at least one row is affected.
-    IF NOT FOUND THEN
-      RAISE WARNING 'Could not insert. File not in repository set in od_data_media!';
-    END IF;
+      dm_oid, -- fk_data_media
+      NEW.remark);
 
   RETURN NEW;
 END; $BODY$

--- a/datamodel/app/view/varia/vw_file.sql
+++ b/datamodel/app/view/varia/vw_file.sql
@@ -58,8 +58,8 @@ CREATE OR REPLACE FUNCTION tww_app.vw_file_insert()
 $BODY$
 DECLARE
   dm_oid varchar(16);
-  dm_path str;
-  relative_path str;
+  dm_path text;
+  relative_path text;
   BEGIN
 
     NEW._url = replace(NEW._url, '\', '/');

--- a/datamodel/app/view/varia/vw_file.sql
+++ b/datamodel/app/view/varia/vw_file.sql
@@ -64,7 +64,7 @@ DECLARE
 
     NEW._url = replace(NEW._url, '\', '/');
 
-    SELECT obj_id, "path" INTO dm_oid, dm_path 
+    SELECT obj_id, "path" INTO dm_oid, dm_path
     FROM tww_od.data_media
     WHERE "path" = SUBSTRING(NEW._url FROM 1 FOR LENGTH("path"))
     ORDER BY LENGTH("path") DESC

--- a/datamodel/app/view/varia/vw_file.sql
+++ b/datamodel/app/view/varia/vw_file.sql
@@ -22,7 +22,7 @@ CREATE OR REPLACE VIEW tww_app.vw_file AS
     f.object,
     f.classname,
     -- dm.path,
-    COALESCE(dm.path::text ||'/'|| f.path_relative::text, f.path_relative::text) AS _url,
+    COALESCE(regexp_replace(dm.path, '[\\/]+$', '')||'/'|| f.path_relative::text, f.path_relative::text) AS _url,
     f.fk_dataowner as dataowner,
     f.fk_provider as provider,
     f.remark
@@ -88,8 +88,8 @@ DECLARE
       (
         dm_path,
         CASE
-          WHEN url ~* '^https?://' THEN 9318 -- webserver
-          WHEN url ~ '^\\\\' THEN 3789       -- server
+          WHEN _url ~* '^https?://' THEN 9318 -- webserver
+          WHEN _url ~ '^\\\\' THEN 3789       -- server
           ELSE 3788                          -- harddisc
         END,
         NEW.dataowner,


### PR DESCRIPTION
---
---
## General
 - [x] Fix a bug
 - [ ] Add a feature
 - [x] Maintenance / sustainability
 - [ ] Add Documentation

## Describe your changes

Refactored `tww_app.vw_file_insert()` to automatically create a matching `tww_od.data_media` entry when a file is inserted from an unknown repository path.

Previously, file insertion depended on the existence of a matching `data_media.path`. If no matching repository was configured, the insert silently failed and only raised a warning:

> Could not insert. File not in repository set in od_data_media!

The new implementation:

- searches for the best matching `data_media` using the existing longest-prefix logic
- automatically creates a new `data_media` record when no match is found
- derives the `data_media.kind` from the URL/path format (webserver, server, harddisc)
- stores the newly created `data_media` reference in `tww_od.file`
- centralizes path decomposition within the trigger and avoids duplicate path extraction during insert

Benefits:

- fixes file import failures for repositories that were not preconfigured
- improves robustness for new installations and migrated environments
- reduces administrative overhead by creating repository definitions on demand
- keeps backward compatibility with existing repository matching behavior

## Screenshots

N/A (database trigger / backend change only)
## Issue ticket number and link
#1171 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CI Tests are green
- [ ] The documentation is up to date with the proposed change.
- [ ] My work is ready for review

## Checklist before merge
- [ ] A review has been performed
- [ ] Comments are resolved
- [ ] Documentation is ready
