### PR TITLE
Add Docs on how to translate an xtf from french to german

### DIFF
--- a/docs/en/admin-guide/interlis-io/index.rst
+++ b/docs/en/admin-guide/interlis-io/index.rst
@@ -389,7 +389,7 @@ Motivation
 
 So far, TEKSI Wastewater only is able to import INTERLIS data in german. For any non-german speaking user, this means that any incoming INTERLIS delivery has to be translated into german before starting the import.
 
-The following description relies heavily on `sjib's blog post in 2022 <https://www.sjib.ch/wie-uebersetze-ich-eine-interlis-transferdatei-in-eine-andere-sprache/>`_, where the process was described in german: 
+The following description relies heavily on `sjib's blog post in 2022 <https://www.sjib.ch/wie-uebersetze-ich-eine-interlis-transferdatei-in-eine-andere-sprache/>`_, where the process was described in german:
 
 Step by step
 ------------
@@ -450,4 +450,3 @@ The basket name can be found in the original transfer dataset.
    java -jar %ili2pg_path% –export –models DSS_2020_1_LV95 –exportModels DSS_2020_1_LV95 –baskets %baskets% –skipReferenceErrors –sqlEnableNull –createEnumTabs –createFk –noSmartMapping –defaultSrsAuth EPSG –defaultSrsCode 2056 –dbhost %host% –dbport %port% –dbdatabase %db% –dbschema %dbschema% –dbusr %user% –dbpwd %pwd% –log %xtf_path%%dbschema%_export.log –trace %xtf_path%%xtf_filename%.xtf
 
 The generated transfer dataset now contains the data in German, except for free-text attributes such as names, labels, or comments.
-

--- a/docs/en/admin-guide/interlis-io/index.rst
+++ b/docs/en/admin-guide/interlis-io/index.rst
@@ -380,3 +380,74 @@ Quality control with VSA online checker (Fachprüfung mit VSA Checker (online))
 
 
 `Information about access and licensing you can get here <https://vsa.ch/Mediathek/gep-datachecker-jahresgebuehr/?media_filter_two=lizenzen-software>`_
+
+Translating an INTERLIS transfer file into another language
+================================================================
+
+Motivation
+----------
+
+So far, TEKSI Wastewater only is able to import INTERLIS data in german. For any non-german speaking user, this means that any incoming INTERLIS delivery has to be translated into german before starting the import.
+
+The following description relies heavily on `sjib's blog post in 2022 <https://www.sjib.ch/wie-uebersetze-ich-eine-interlis-transferdatei-in-eine-andere-sprache/>`_, where the process was described in german: 
+
+Step by step
+------------
+
+Download and install a `current ili2pg version <https://www.interlis.ch/downloads/ili2db>`_, version 4.9.0 or newer. The following example uses a small Windows batch file. Its header defines the database, password, PostgreSQL installation path, local INTERLIS model directory, port, host, and user:
+
+.. code-block:: batch
+
+   set db=dss_translate
+   set pwd=mypassword
+   set PATH=%PATH%;C:/Program Files/PostgreSQL/18/bin
+   set port=5432
+   set host=localhost
+   set user=postgres
+   set dbschema=sdee_traduction_f_d
+
+   set ili2pg_path=C:/Daten/ili2pg-4.9.0/ili2pg-4.9.0.jar
+   set xtf_path=%userprofile%/Downloads/
+   set xtf_filename=SDEE_2020_1_LV95.xtf
+
+.. note::
+
+   For the process to work correctly, the model directory must contain all INTERLIS model files in both German and French.
+
+The following sections describe the required steps.
+
+1. Create the empty schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example uses ``SDEE_2020_1_LV95`` and its corresponding French model, ``DSS_2020_1_LV95``.
+
+.. code-block:: batch
+
+   java -jar %ili2pg_path% –schemaimport –importTid –sqlEnableNull –createEnumTabs –createBasketCol  –createFk –noSmartMapping –defaultSrsAuth EPSG –defaultSrsCode 2056 –dbhost %host% –dbport %port% –dbdatabase %db% –dbschema %dbschema% –dbusr %user% –dbpwd %pwd% –log %xtf_path%%dbschema%_schemaimport.log –trace –models SDEE_2020_1_LV95; DSS_2020_1_LV95;
+
+Normally, only one model version is passed to the ``–models`` parameter. For a translation, both language versions are required: ``–models SDEE_2020_1_LV95; DSS_2020_1_LV95;``
+
+
+2. Import the French transfer dataset into the schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: batch
+
+   java -jar %ili2pg_path% –disableValidation –import –deleteData –modeldir %ilimodelpath% –trace –sqlEnableNull –createEnumTabs –createBasketCol –createFk –defaultSrsCode 2056 –noSmartMapping –dbhost %host% –dbport %port% –dbdatabase %db% –dbschema %dbschema% –dbusr %user% –dbpwd %pwd% –log %xtf_path%%dbschema%_import.log %xtf_path%%xtf_filename%
+
+The data is now stored in French in the PostgreSQL schema.
+
+3. Export the data and translate it into German
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The target language is selected with the following parameters: ``–export –models DSS_2020_1_LV95 –exportModels DSS_2020_1_LV95``.
+The basket name can be found in the original transfer dataset.
+
+.. code-block:: batch
+
+   set xtf_filename=DSS_2020_1_LV95.xtf
+   set baskets=BASKET_1
+   java -jar %ili2pg_path% –export –models DSS_2020_1_LV95 –exportModels DSS_2020_1_LV95 –baskets %baskets% –skipReferenceErrors –sqlEnableNull –createEnumTabs –createFk –noSmartMapping –defaultSrsAuth EPSG –defaultSrsCode 2056 –dbhost %host% –dbport %port% –dbdatabase %db% –dbschema %dbschema% –dbusr %user% –dbpwd %pwd% –log %xtf_path%%dbschema%_export.log –trace %xtf_path%%xtf_filename%.xtf
+
+The generated transfer dataset now contains the data in German, except for free-text attributes such as names, labels, or comments.
+


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to propose some new content (bugfix, feature, maintenance or sustainability)
title: 'Add English documentation for translating INTERLIS transfer files'
labels: 'documentation'
assignees: ''
---

## General

- [ ] Fix a bug
- [ ] Add a feature
- [ ] Maintenance / sustainability
- [x] Add Documentation

## Describe your changes

This pull request adds an guide explaining how to translate an INTERLIS transfer file into another language using ili2pg. It is basically a translation of www.sjib.ch/wie-uebersetze-ich-eine-interlis-transferdatei-in-eine-andere-sprache/ updated to DSS 2020.1 and swapping languages.

Re-adding it here adds the advantage of being translated through Transifex.

## Screenshots


## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CI Tests are green
- [x] The documentation is up to date with the proposed change.
- [ ] My work is ready for review

## Checklist before merge

- [ ] A review has been performed
- [ ] Comments are resolved
- [ ] Documentation is ready